### PR TITLE
Fixed error:

### DIFF
--- a/neat/activations.py
+++ b/neat/activations.py
@@ -80,7 +80,7 @@ def validate_activation(function):
     if not inspect.isfunction(function):
         raise InvalidActivationFunction("A function object is required.")
 
-    args = inspect.getargspec(function.__call__)
+    args = inspect.getargspec(function)
     if len(args[0]) != 1:
         raise InvalidActivationFunction("A single-argument function is required.")
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "evolve-feedforward.py", line 63, in <module>
    run(config_path)
  File "evolve-feedforward.py", line 28, in run
    config_file)
  File "/Users/catap/Documents/OpenSource/neat-python/neat/config.py", line 107, in __init__
    self.genome_config = genome_type.parse_config(genome_dict)
  File "/Users/catap/Documents/OpenSource/neat-python/neat/genome.py", line 106, in parse_config
    return DefaultGenomeConfig(param_dict)
  File "/Users/catap/Documents/OpenSource/neat-python/neat/genome.py", line 35, in __init__
    self.activation_defs = ActivationFunctionSet()
  File "/Users/catap/Documents/OpenSource/neat-python/neat/activations.py", line 91, in __init__
    self.add('sigmoid', sigmoid_activation)
  File "/Users/catap/Documents/OpenSource/neat-python/neat/activations.py", line 108, in add
    validate_activation(function)
  File "/Users/catap/Documents/OpenSource/neat-python/neat/activations.py", line 83, in validate_activation
    args = inspect.getargspec(function.__call__)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/inspect.py", line 816, in getargspec
    raise TypeError('{!r} is not a Python function'.format(func))
TypeError: <method-wrapper '__call__' of function object at 0x100881e60> is not a Python function
```