### PR TITLE
update neat.StdOutReporter

### DIFF
--- a/examples/picture2d/evolve_interactive.py
+++ b/examples/picture2d/evolve_interactive.py
@@ -236,7 +236,7 @@ def run():
     pop = neat.Population(config)
 
     # Add a stdout reporter to show progress in the terminal.
-    pop.add_reporter(neat.StdOutReporter())
+    pop.add_reporter(neat.StdOutReporter(True))
     stats = neat.StatisticsReporter()
     pop.add_reporter(stats)
 


### PR DESCRIPTION
Error when closing main window:
Traceback (most recent call last):
  File "D:/.../neat-python-master/examples/picture2d/evolve_interactive.py", line 248, in <module>
    run()
  File "D:/Projects/neat-python-master/examples/picture2d/evolve_interactive.py", line 245, in run
    pop.run(pb.eval_fitness, 1)
  File "F:\Anaconda2\lib\site-packages\neat\population.py", line 96, in run
    self.species, self.config.pop_size, self.generation)
  File "F:\Anaconda2\lib\site-packages\neat\reproduction.py", line 78, in reproduce
    for sid, s, stagnant in self.stagnation.update(species, generation):
TypeError: update() takes exactly 2 arguments (3 given)