### PR TITLE
Error '__file__' is not defined

### DIFF
--- a/examples/xor/evolve-spiking.py
+++ b/examples/xor/evolve-spiking.py
@@ -155,5 +155,5 @@ def run(config_path):
 
 
 if __name__ == '__main__':
-    local_dir = os.path.dirname(__file__)
+    local_dir = os.path.dirname('__file__')
     run(os.path.join(local_dir, 'config-spiking'))


### PR DESCRIPTION
Quotation marks are required to avoid error: "os.path.dirname(__file__) global name '__file__' is not defined"