### PR TITLE
Error '__file__' is not defined

### DIFF
--- a/examples/xor/evolve-feedforward-partial.py
+++ b/examples/xor/evolve-feedforward-partial.py
@@ -62,6 +62,6 @@ if __name__ == '__main__':
     # Determine path to configuration file. This path manipulation is
     # here so that the script will run successfully regardless of the
     # current working directory.
-    local_dir = os.path.dirname(__file__)
+    local_dir = os.path.dirname('__file__')
     config_path = os.path.join(local_dir, 'config-feedforward-partial')
     run(config_path)


### PR DESCRIPTION
Quotation marks are required to avoid error: "os.path.dirname(__file__) global name '__file__' is not defined"