### PR TITLE
Don't allow connections between two input(output) nodes

### DIFF
--- a/neat/genome.py
+++ b/neat/genome.py
@@ -253,6 +253,14 @@ class DefaultGenome(object):
         if key in self.connections:
             return
 
+        # Don't allow connections between two output nodes
+        if in_node in config.output_keys and out_node in config.output_keys:
+            return
+
+        # Don't allow connections between two input nodes
+        if in_node in config.input_keys and out_node in config.input_keys:
+            return
+
         # For feed-forward networks, avoid creating cycles.
         if config.feed_forward and creates_cycle(list(iterkeys(self.connections)), key):
             return


### PR DESCRIPTION
Assume now we have two input nodes -1 and -2, three output nodes 0, 1, 2 and two hidden nodes 3, 4. We have 4 connections (-1, 4) (-2, 3) (4, 3) (3, 2). Now connection mutation happens, a new connection (1, 2) occurs. So we have 5 connections in total. If you look into the function ```feed_forward_layers``` in ```graphs.py```, you will find in this case the function doesn't work as expected. it only returns [set(4), set(3)], so the output node will always be 0. To avoid this, we should forbid connections between two output(input) nodes.
I discover this because I'm try to do back propagation.