### PR TITLE
Clamp mutated values in FloatAttribute

### DIFF
--- a/neat/attributes.py
+++ b/neat/attributes.py
@@ -46,7 +46,7 @@ class FloatAttribute(BaseAttribute):
         mutate_rate = getattr(config, self.mutate_rate_name)
         if r < replace_rate + mutate_rate:
             mutate_power = getattr(config, self.mutate_power_name)
-            return value + gauss(0.0, mutate_power)
+            return self.clamp(value + gauss(0.0, mutate_power), config)
 
         return self.clamp(value, config)
 

--- a/neat/attributes.py
+++ b/neat/attributes.py
@@ -48,7 +48,7 @@ class FloatAttribute(BaseAttribute):
             mutate_power = getattr(config, self.mutate_power_name)
             return self.clamp(value + gauss(0.0, mutate_power), config)
 
-        return self.clamp(value, config)
+        return value
 
     def validate(self, config):
         pass


### PR DESCRIPTION
This is to solve the missing clamping of values after mutation (as opposed to after replacement or if no mutation took place). I have confirmed that all the tests run properly with this change; I have not checked the examples other than xor. (If anything did run worse, this would appear to be an indication that the prior min/max range was too small. The second change - deletion of trailing whitespace - was due to my editor, Xcode, BTW.)

-Allen