### PR TITLE
add ThreadedEvaluator; fix docstring of ParallelEvaluator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "3.7-dev"
   - "nightly"
   - "pypy"
-  - "pypy3"
+  - "pypy3.5-5.8.0"
 install:
     pip install nose coveralls coverage
 script:

--- a/examples/xor/evolve-feedforward-threaded.py
+++ b/examples/xor/evolve-feedforward-threaded.py
@@ -47,6 +47,7 @@ def eval_genome(genome, config):
 
 
 def run(config_file):
+    """load the config, create a population, evolve and show the result"""
     # Load configuration.
     config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
                          neat.DefaultSpeciesSet, neat.DefaultStagnation,
@@ -63,6 +64,7 @@ def run(config_file):
     # Run for up to 300 generations.
     pe = neat.ThreadedEvaluator(4, eval_genome)
     winner = p.run(pe.evaluate, 300)
+    pe.stop()
 
     # Display the winning genome.
     print('\nBest genome:\n{!s}'.format(winner))

--- a/examples/xor/evolve-feedforward-threaded.py
+++ b/examples/xor/evolve-feedforward-threaded.py
@@ -1,0 +1,88 @@
+"""
+A threaded version of XOR using neat.threaded.
+
+Since most python implementations use a GIL, a threaded version probably won't
+run any faster than the single-threaded version.
+
+If your evaluation function is what's taking up most of your processing time
+(and you should check by using a profiler while running single-threaded) and
+your python implementation does not use a GIL,
+you should see a significant performance improvement by evaluating using
+multiple threads.
+
+This example is only intended to show how to do a threaded experiment
+in neat-python.  You can of course roll your own threading mechanism
+or inherit from ThreadedEvaluator if you need to do something more complicated.
+"""
+
+from __future__ import print_function
+
+import os
+
+import neat
+
+import visualize
+
+# 2-input XOR inputs and expected outputs.
+xor_inputs = [(0.0, 0.0), (0.0, 1.0), (1.0, 0.0), (1.0, 1.0)]
+xor_outputs = [(0.0,),     (1.0,),     (1.0,),     (0.0,)]
+
+
+def eval_genome(genome, config):
+    """
+    This function will be run in threads by ThreadedEvaluator.  It takes two
+    arguments (a single genome and the genome class configuration data) and
+    should return one float (that genome's fitness).
+    """
+
+    net = neat.nn.FeedForwardNetwork.create(genome, config)
+    error = 4.0
+    for xi, xo in zip(xor_inputs, xor_outputs):
+        output = net.activate(xi)
+        error -= (output[0] - xo[0]) ** 2
+    return error
+
+
+def run(config_file):
+    # Load configuration.
+    config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
+                         neat.DefaultSpeciesSet, neat.DefaultStagnation,
+                         config_file)
+
+    # Create the population, which is the top-level object for a NEAT run.
+    p = neat.Population(config)
+
+    # Add a stdout reporter to show progress in the terminal.
+    p.add_reporter(neat.StdOutReporter(True))
+    stats = neat.StatisticsReporter()
+    p.add_reporter(stats)
+
+    # Run for up to 300 generations.
+    pe = neat.ThreadedEvaluator(4, eval_genome)
+    winner = p.run(pe.evaluate, 300)
+
+    # Display the winning genome.
+    print('\nBest genome:\n{!s}'.format(winner))
+
+    # Show output of the most fit genome against training data.
+    print('\nOutput:')
+    winner_net = neat.nn.FeedForwardNetwork.create(winner, config)
+    for xi, xo in zip(xor_inputs, xor_outputs):
+        output = winner_net.activate(xi)
+        print(
+            "input {!r}, expected output {!r}, got {!r}".format(xi, xo, output)
+            )
+
+    node_names = {-1: 'A', -2: 'B', 0: 'A XOR B'}
+    visualize.draw_net(config, winner, True, node_names=node_names)
+    visualize.plot_stats(stats, ylog=False, view=True)
+    visualize.plot_species(stats, view=True)
+
+
+if __name__ == '__main__':
+    # Determine path to configuration file. This path manipulation is
+    # here so that the script will run successfully regardless of the
+    # current working directory.
+    local_dir = os.path.dirname(__file__)
+    config_path = os.path.join(local_dir, 'config-feedforward')
+    run(config_path)

--- a/examples/xor/evolve-feedforward-threaded.py
+++ b/examples/xor/evolve-feedforward-threaded.py
@@ -21,7 +21,10 @@ import os
 
 import neat
 
-import visualize
+try:
+	import visualize
+except ImportError:
+	visualize = None
 
 # 2-input XOR inputs and expected outputs.
 xor_inputs = [(0.0, 0.0), (0.0, 1.0), (1.0, 0.0), (1.0, 1.0)]
@@ -73,10 +76,11 @@ def run(config_file):
             "input {!r}, expected output {!r}, got {!r}".format(xi, xo, output)
             )
 
-    node_names = {-1: 'A', -2: 'B', 0: 'A XOR B'}
-    visualize.draw_net(config, winner, True, node_names=node_names)
-    visualize.plot_stats(stats, ylog=False, view=True)
-    visualize.plot_species(stats, view=True)
+    if visualize is not None:
+        node_names = {-1: 'A', -2: 'B', 0: 'A XOR B'}
+        visualize.draw_net(config, winner, True, node_names=node_names)
+        visualize.plot_stats(stats, ylog=False, view=True)
+        visualize.plot_species(stats, view=True)
 
 
 if __name__ == '__main__':

--- a/neat/__init__.py
+++ b/neat/__init__.py
@@ -11,4 +11,5 @@ from neat.reporting import StdOutReporter
 from neat.species import DefaultSpeciesSet
 from neat.statistics import StatisticsReporter
 from neat.parallel import ParallelEvaluator
+from neat.threaded import ThreadedEvaluator
 from neat.checkpoint import Checkpointer

--- a/neat/parallel.py
+++ b/neat/parallel.py
@@ -4,8 +4,8 @@ from multiprocessing import Pool
 class ParallelEvaluator(object):
     def __init__(self, num_workers, eval_function, timeout=None):
         '''
-        eval_function should take one argument (a genome object) and return
-        a single float (the genome's fitness).
+        eval_function should take two arguments (a genome object and the
+        configuration) and return a single float (the genome's fitness).
         '''
         self.num_workers = num_workers
         self.eval_function = eval_function

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -25,6 +25,12 @@ class ThreadedEvaluator(object):
         self.outqueue = queue.Queue()
 
     def __del__(self):
+        """
+        Called on deletion of the object. We stop our workers here.
+        WARNING: __del__ may not always work!
+        please stop the threads explicitly by calling self.stop()!
+        todo: ensure that there are no reference-cycles.
+        """
         if self.working:
             self.stop()
             
@@ -47,12 +53,16 @@ class ThreadedEvaluator(object):
         self.working = False
         for w in self.workers:
             w.join()
+        self.workers = []
 
     def _worker(self):
         """the worker function"""
         while self.working:
             try:
-                genome_id, genome, config = self.inqueue.get(block=True, timeout=0.2)
+                genome_id, genome, config = self.inqueue.get(
+                    block=True,
+                    timeout=0.2,
+                    )
             except queue.Empty:
                 continue
             f = self.eval_function(genome, config)

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -14,8 +14,8 @@ class ThreadedEvaluator(object):
     """
     def __init__(self, num_workers, eval_function):
         '''
-        eval_function should take one argument (a genome object) and return
-        a single float (the genome's fitness).
+        eval_function should take two arguments (a genome object and the
+        configuration) and return a single float (the genome's fitness).
         '''
         self.num_workers = num_workers
         self.eval_function = eval_function
@@ -52,10 +52,10 @@ class ThreadedEvaluator(object):
         """the worker function"""
         while self.working:
             try:
-                genome_id, genome = self.inqueue.get(block=True, timeout=0.2)
+                genome_id, genome, config = self.inqueue.get(block=True, timeout=0.2)
             except queue.Empty:
                 continue
-            f = self.eval_function(genome)
+            f = self.eval_function(genome, config)
             self.outqueue.put((genome_id, genome, f))
 
     def evaluate(self, genomes, config):
@@ -65,7 +65,7 @@ class ThreadedEvaluator(object):
         p = 0
         for genome_id, genome in genomes:
             p += 1
-            self.inqueue.put((genome_id, genome))
+            self.inqueue.put((genome_id, genome, config))
 
         # assign the fitness back to each genome
         while p > 0:

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -60,6 +60,8 @@ class ThreadedEvaluator(object):
 
     def evaluate(self, genomes, config):
         """evaluate the genomes"""
+        if not self.working:
+            self.start()
         p = 0
         for genome_id, genome in genomes:
             p += 1

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -33,7 +33,7 @@ class ThreadedEvaluator(object):
         if self.working:
             return
         self.working = True
-        for i in xrange(self.num_workers):
+        for i in range(self.num_workers):
             w = threading.Thread(
                 name="Worker Thread #{i}".format(i=i),
                 target=self._worker,

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -1,0 +1,72 @@
+"""threaded evaluation of genomes"""
+import threading
+
+try:
+    import Queue as queue
+except ImportError:
+    import queue
+
+
+class ThreadedEvaluator(object):
+    """
+    A threaded genome evaluator.
+    Usefull on python implementations without GIL.
+    """
+    def __init__(self, num_workers, eval_function):
+        '''
+        eval_function should take one argument (a genome object) and return
+        a single float (the genome's fitness).
+        '''
+        self.num_workers = num_workers
+        self.eval_function = eval_function
+        self.workers = []
+        self.working = False
+        self.inqueue = queue.Queue()
+        self.outqueue = queue.Queue()
+
+    def __del__(self):
+        if self.working:
+            self.stop()
+            
+    def start(self):
+        """starts the worker threads"""
+        if self.working:
+            return
+        self.working = True
+        for i in xrange(self.num_workers):
+            w = threading.Thread(
+                name="Worker Thread #{i}".format(i=i),
+                target=self._worker,
+                )
+            w.daemon = True
+            w.start()
+            self.workers.append(w)
+
+    def stop(self):
+        """stops the worker threads and wait for them to finish"""
+        self.working = False
+        for w in self.workers:
+            w.join()
+
+    def _worker(self):
+        """the worker function"""
+        while self.working:
+            try:
+                genome_id, genome = self.inqueue.get(block=True, timeout=0.2)
+            except queue.Empty:
+                continue
+            f = self.eval_function(genome)
+            self.outqueue.put((genome_id, genome, f))
+
+    def evaluate(self, genomes, config):
+        """evaluate the genomes"""
+        p = 0
+        for genome_id, genome in genomes:
+            p += 1
+            self.inqueue.put((genome_id, genome))
+
+        # assign the fitness back to each genome
+        while p > 0:
+            p -= 1
+            genome_id, genome, fitness = self.outqueue.get()
+            genome.fitness = fitness

--- a/tests/test_simple_run.py
+++ b/tests/test_simple_run.py
@@ -13,6 +13,7 @@ def eval_dummy_genomes_nn(genomes, config):
 
 
 def test_serial():
+    """tests normal evolution and evaluation"""
     # Load configuration.
     local_dir = os.path.dirname(__file__)
     config_path = os.path.join(local_dir, 'test_configuration')
@@ -45,6 +46,7 @@ def test_serial():
 
 
 def test_parallel():
+    """tests parallel evolution and evaluation"""
     # Load configuration.
     local_dir = os.path.dirname(__file__)
     config_path = os.path.join(local_dir, 'test_configuration')
@@ -67,7 +69,8 @@ def test_parallel():
     stats.save()
 
 
-def test_threaded():
+def test_threaded_evaluation():
+    """tests a neat evolution using neat.threaded.ThreadedEvaluator"""
     # Load configuration.
     local_dir = os.path.dirname(__file__)
     config_path = os.path.join(local_dir, 'test_configuration')
@@ -88,6 +91,62 @@ def test_threaded():
     p.run(pe.evaluate, 300)
 
     stats.save()
+
+
+def test_threaded_evaluator():
+    """tests generall functionality of neat.threaded.ThreadedEvaluator"""
+    n_workers = 3
+    e = neat.ThreadedEvaluator(n_workers, eval_dummy_genome_nn)
+    # ensure workers are not started
+    if (len(e.workers) > 0) or (e.working):
+        raise Exception("ThreadedEvaluator started on __init__()!")
+    # ensure start() starts the workers
+    e.start()
+    if (len(e.workers) != n_workers) or (not e.working):
+        raise Exception("ThreadedEvaluator did not start on start()!")
+    w = e.workers[0]
+    if not w.is_alive():
+        raise Exception("Workers did not start on start()")
+    # ensure a second call to start() does nothing when already started
+    e.start()
+    if (len(e.workers) != n_workers) or (not e.working):
+        raise Exception(
+            "A second ThreadedEvaluator.start() call was not ignored!"
+            )
+    w = e.workers[0]
+    if not w.is_alive():
+        raise Exception("A worker died or stopped!")
+    # ensure stop() works
+    e.stop()
+    if (len(e.workers) != 0) or (e.working):
+        raise Exception(
+            "ThreadedEvaluator.stop() did not work!"
+            )
+    if w.is_alive():
+        raise Exception("A worker is still alive!")
+    # ensure a second call to stop() does nothing when already stopped
+    e.stop()
+    if (len(e.workers) != 0) or (e.working):
+        raise Exception(
+            "A second ThreadedEvaluator.stop() call was not ignored!"
+            )
+    if w.is_alive():
+        raise Exception("A worker is still alive or was resurrected!")
+    # ensure a restart is possible
+    # ensure start() starts the workers
+    e.start()
+    if (len(e.workers) != n_workers) or (not e.working):
+        raise Exception("ThreadedEvaluator did not restart on start()!")
+    w = e.workers[0]
+    if not w.is_alive():
+        raise Exception("Workers did not start on start()")
+    # ensure del stops workers
+    del e
+    # unfortunately, __del__() may never be called, even when using del
+    # this means that testing for __del__() to call stop() may not work
+    # this test had a high random failure rate, so i removed it.
+    # if w.is_alive():
+    #     raise Exception("__del__() did not stop workers!")
 
 
 def eval_dummy_genomes_nn_recurrent(genomes, config):
@@ -181,4 +240,6 @@ def test_run_iznn():
 
 if __name__ == '__main__':
     test_serial()
+    test_threaded_evaluator()
+    test_threaded_evaluation()
     test_parallel()

--- a/tests/test_simple_run.py
+++ b/tests/test_simple_run.py
@@ -33,10 +33,10 @@ def test_serial():
     p.run(eval_dummy_genomes_nn, 300)
 
     stats.save()
-    #stats.save_genome_fitness(with_cross_validation=True)
+    # stats.save_genome_fitness(with_cross_validation=True)
 
     stats.get_fitness_stdev()
-    #stats.get_average_cross_validation_fitness()
+    # stats.get_average_cross_validation_fitness()
     stats.best_unique_genomes(5)
     stats.best_genomes(5)
     stats.best_genome()
@@ -62,6 +62,29 @@ def test_parallel():
 
     # Run for up to 300 generations.
     pe = neat.ParallelEvaluator(4, eval_dummy_genome_nn)
+    p.run(pe.evaluate, 300)
+
+    stats.save()
+
+
+def test_threaded():
+    # Load configuration.
+    local_dir = os.path.dirname(__file__)
+    config_path = os.path.join(local_dir, 'test_configuration')
+    config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
+                         neat.DefaultSpeciesSet, neat.DefaultStagnation,
+                         config_path)
+
+    # Create the population, which is the top-level object for a NEAT run.
+    p = neat.Population(config)
+
+    # Add a stdout reporter to show progress in the terminal.
+    p.add_reporter(neat.StdOutReporter(True))
+    stats = neat.StatisticsReporter()
+    p.add_reporter(stats)
+
+    # Run for up to 300 generations.
+    pe = neat.ThreadedEvaluator(4, eval_dummy_genome_nn)
     p.run(pe.evaluate, 300)
 
     stats.save()


### PR DESCRIPTION
I have added the `neat.threaded.ThreadedEvaluator` and fixed a mistake in the docstring of `neat.parallel.ParallelEvaluator.__init__`.
the `ThreadedEvaluator`-class is like the `ParallelEvaluator`-class, but uses threads instead of processes.
This is useful when using python implementations without an GIL like jython.
I also created an example of the `ThreadedEvaluator` based on `examples/xor/evolve-feedforward-parallel.py`.

The docstring of `neat.parallel.ParallelEvaluator.__init__` stated that *`eval_function` should take one argument (the genome object)[...]*. However, `eval_function` is called with two arguments (the genome object and the config). This is now corrected.

**Edit:** This PR now also modifies `.travis.yml` to enforce the usage `pypy3.5-5.8.0` instead of `pypy3`. Travis uses an old pypy3, which causes some bugs in multithreaded script.