### PR TITLE
add ThreadedEvaluator and DistributedEvaluator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "3.7-dev"
   - "nightly"
   - "pypy"
-  - "pypy3"
+  - "pypy3.5-5.8.0"
 install:
     pip install nose coveralls coverage
 script:

--- a/examples/xor/evolve-feedforward-distributed.py
+++ b/examples/xor/evolve-feedforward-distributed.py
@@ -1,0 +1,191 @@
+"""
+A distributed version of XOR using neat.distributed.
+
+Since XOR is a simple experiment, a distributed version probably won't run any
+faster than the single-process version, due to the overhead of
+inter-process communication.
+
+If your evaluation function is what's taking up most of your processing time
+(and you should check by using a profiler while running single-process),
+you should see a significant performance improvement by evaluating across
+multiple machines.
+
+This example is only intended to show how to do a distributed experiment
+in neat-python.  You can of course roll your own parallelism mechanism
+or inherit from DistributedEvaluator if you need to do something more
+complicated.
+"""
+
+from __future__ import print_function
+
+import os
+import argparse
+import sys
+
+import neat
+
+import visualize
+
+# 2-input XOR inputs and expected outputs.
+xor_inputs = [(0.0, 0.0), (0.0, 1.0), (1.0, 0.0), (1.0, 1.0)]
+xor_outputs = [(0.0,),     (1.0,),     (1.0,),     (0.0,)]
+
+
+def eval_genome(genome, config):
+    """
+    This function will be run in parallel by ParallelEvaluator.  It takes two
+    arguments (a single genome and the genome class configuration data) and
+    should return one float (that genome's fitness).
+
+    Note that this function needs to be in module scope for multiprocessing.Pool
+    (which is what DistributedEvaluator uses when using more than one worker)
+    to find it.  Because of this, make sure you check for __main__ before
+    executing any code (as we do here in the last few lines in the file),
+    otherwise you'll have made a fork bomb instead of a neuroevolution demo. :)
+    """
+
+    net = neat.nn.FeedForwardNetwork.create(genome, config)
+    error = 4.0
+    for xi, xo in zip(xor_inputs, xor_outputs):
+        output = net.activate(xi)
+        error -= (output[0] - xo[0]) ** 2
+    return error
+
+
+def run(config_file, addr, authkey, mode, workers):
+    # Load configuration.
+    config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
+                         neat.DefaultSpeciesSet, neat.DefaultStagnation,
+                         config_file)
+
+    # Create the population, which is the top-level object for a NEAT run.
+    p = neat.Population(config)
+
+    # Add a stdout reporter to show progress in the terminal.
+    p.add_reporter(neat.StdOutReporter(True))
+    stats = neat.StatisticsReporter()
+    p.add_reporter(stats)
+
+    # setup an DistributedEvaluator
+    de = neat.DistributedEvaluator(
+        addr,  # connect to addr
+        authkey,  # use authkey to authenticate
+        eval_genome,  # use eval_genome() to evaluate a genome
+        slave_chunksize=4,  # send 4 genomes at once
+        num_workers=workers,  # when in slave mode, use this many workers
+        worker_timeout=10,  # when in slave mode and workers > 1,
+                            # wait at most 10 seconds for the result
+        mode=mode,  # wether this is the master or a slave node
+                    # in most case you can simply pass
+                    # 'neat.distributed.MODE_AUTO' as the mode.
+                    # This causes the DistributedEvaluator to
+                    # determine the mode by checking if address
+                    # points to the localhost.
+        )
+
+    # start the DistributedEvaluator
+    de.start(
+        exit_on_stop=True,  # if this is a slave node, call sys.exit(0) when
+                            # when finished. All code after this line will only
+                            # be executed by the master node.
+        slave_wait=3,  # when a slave, sleep this many seconds before continuing
+                       # this is useful when the master node may need more time
+                       # to start than the slave nodes.
+        )
+
+    # Run for up to 500 generations.
+    winner = p.run(de.evaluate, 500)
+
+    # stop evaluator
+    de.stop()
+
+    # Display the winning genome.
+    print('\nBest genome:\n{!s}'.format(winner))
+
+    # Show output of the most fit genome against training data.
+    print('\nOutput:')
+    winner_net = neat.nn.FeedForwardNetwork.create(winner, config)
+    for xi, xo in zip(xor_inputs, xor_outputs):
+        output = winner_net.activate(xi)
+        print("input {!r}, expected output {!r}, got {!r}".format(xi, xo, output))
+
+    node_names = {-1: 'A', -2: 'B', 0: 'A XOR B'}
+    visualize.draw_net(config, winner, True, node_names=node_names)
+    visualize.plot_stats(stats, ylog=False, view=True)
+    visualize.plot_species(stats, view=True)
+
+
+def addr_tuple(s):
+    """converts a string into a tuple of (host, port)"""
+    if "[" in s:
+        # ip v6
+        if (s.count("[") != 1) or (s.count("]") != 1):
+            raise ValueError("Invalid IPv6 address!")
+        end = s.index("]")
+        if ":" not in s[end:]:
+            raise ValueError("IPv6 address does specify a port to use!")
+        host, port = s[1:end], s[end+1:]
+        port = int(port)
+        return (host, port)
+    else:
+        host, port = s.split(":")
+        port = int(port)
+        return (host, port)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="NEAT xor experiment evaluated across multiple machines.")
+    parser.add_argument(
+        "address",
+        help="host:port address of the main node",
+        type=addr_tuple,
+        action="store",
+        )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        help="number of processes to use for evaluating the genomes",
+        action="store",
+        default=1,
+        dest="workers",
+        )
+    parser.add_argument(
+        "--authkey",
+        action="store",
+        help="authkey to use (default: 'neat-python')",
+        default="neat-python",
+        dest="authkey",
+        )
+    parser.add_argument(
+        "--force-slave",
+        action="store_const",
+        const=neat.distributed.MODE_SLAVE,
+        default=neat.distributed.MODE_AUTO,
+        help="Force slave mode (useful for debugging)",
+        dest="mode",
+        )
+    ns = parser.parse_args()
+
+    address = ns.address
+    host, port = address
+    workers = ns.workers
+    authkey = ns.authkey
+    mode = ns.mode
+
+    if host in ("0.0.0.0", "localhost", ""):
+        # print an error message
+        # we are using auto-mode determination in this example,
+        # which does not work well with '0.0.0.0' or 'localhost'.
+        print("Please do not use '0.0.0.0' or 'localhost' as host.")
+        sys.exit(1)
+
+    # Determine path to configuration file. This path manipulation is
+    # here so that the script will run successfully regardless of the
+    # current working directory.
+    local_dir = os.path.dirname(__file__)
+    config_path = os.path.join(local_dir, 'config-feedforward')
+
+    print("Starting Node...")
+    print("Please ensure that you are using more than one node.")
+
+    run(config_path, address, authkey, mode, workers)

--- a/examples/xor/evolve-feedforward-threaded.py
+++ b/examples/xor/evolve-feedforward-threaded.py
@@ -47,6 +47,7 @@ def eval_genome(genome, config):
 
 
 def run(config_file):
+    """load the config, create a population, evolve and show the result"""
     # Load configuration.
     config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
                          neat.DefaultSpeciesSet, neat.DefaultStagnation,
@@ -63,6 +64,7 @@ def run(config_file):
     # Run for up to 300 generations.
     pe = neat.ThreadedEvaluator(4, eval_genome)
     winner = p.run(pe.evaluate, 300)
+    pe.stop()
 
     # Display the winning genome.
     print('\nBest genome:\n{!s}'.format(winner))

--- a/examples/xor/evolve-feedforward-threaded.py
+++ b/examples/xor/evolve-feedforward-threaded.py
@@ -1,0 +1,88 @@
+"""
+A threaded version of XOR using neat.threaded.
+
+Since most python implementations use a GIL, a threaded version probably won't
+run any faster than the single-threaded version.
+
+If your evaluation function is what's taking up most of your processing time
+(and you should check by using a profiler while running single-threaded) and
+your python implementation does not use a GIL,
+you should see a significant performance improvement by evaluating using
+multiple threads.
+
+This example is only intended to show how to do a threaded experiment
+in neat-python.  You can of course roll your own threading mechanism
+or inherit from ThreadedEvaluator if you need to do something more complicated.
+"""
+
+from __future__ import print_function
+
+import os
+
+import neat
+
+import visualize
+
+# 2-input XOR inputs and expected outputs.
+xor_inputs = [(0.0, 0.0), (0.0, 1.0), (1.0, 0.0), (1.0, 1.0)]
+xor_outputs = [(0.0,),     (1.0,),     (1.0,),     (0.0,)]
+
+
+def eval_genome(genome, config):
+    """
+    This function will be run in threads by ThreadedEvaluator.  It takes two
+    arguments (a single genome and the genome class configuration data) and
+    should return one float (that genome's fitness).
+    """
+
+    net = neat.nn.FeedForwardNetwork.create(genome, config)
+    error = 4.0
+    for xi, xo in zip(xor_inputs, xor_outputs):
+        output = net.activate(xi)
+        error -= (output[0] - xo[0]) ** 2
+    return error
+
+
+def run(config_file):
+    # Load configuration.
+    config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
+                         neat.DefaultSpeciesSet, neat.DefaultStagnation,
+                         config_file)
+
+    # Create the population, which is the top-level object for a NEAT run.
+    p = neat.Population(config)
+
+    # Add a stdout reporter to show progress in the terminal.
+    p.add_reporter(neat.StdOutReporter(True))
+    stats = neat.StatisticsReporter()
+    p.add_reporter(stats)
+
+    # Run for up to 300 generations.
+    pe = neat.ThreadedEvaluator(4, eval_genome)
+    winner = p.run(pe.evaluate, 300)
+
+    # Display the winning genome.
+    print('\nBest genome:\n{!s}'.format(winner))
+
+    # Show output of the most fit genome against training data.
+    print('\nOutput:')
+    winner_net = neat.nn.FeedForwardNetwork.create(winner, config)
+    for xi, xo in zip(xor_inputs, xor_outputs):
+        output = winner_net.activate(xi)
+        print(
+            "input {!r}, expected output {!r}, got {!r}".format(xi, xo, output)
+            )
+
+    node_names = {-1: 'A', -2: 'B', 0: 'A XOR B'}
+    visualize.draw_net(config, winner, True, node_names=node_names)
+    visualize.plot_stats(stats, ylog=False, view=True)
+    visualize.plot_species(stats, view=True)
+
+
+if __name__ == '__main__':
+    # Determine path to configuration file. This path manipulation is
+    # here so that the script will run successfully regardless of the
+    # current working directory.
+    local_dir = os.path.dirname(__file__)
+    config_path = os.path.join(local_dir, 'config-feedforward')
+    run(config_path)

--- a/examples/xor/evolve-feedforward-threaded.py
+++ b/examples/xor/evolve-feedforward-threaded.py
@@ -21,7 +21,10 @@ import os
 
 import neat
 
-import visualize
+try:
+	import visualize
+except ImportError:
+	visualize = None
 
 # 2-input XOR inputs and expected outputs.
 xor_inputs = [(0.0, 0.0), (0.0, 1.0), (1.0, 0.0), (1.0, 1.0)]
@@ -73,10 +76,11 @@ def run(config_file):
             "input {!r}, expected output {!r}, got {!r}".format(xi, xo, output)
             )
 
-    node_names = {-1: 'A', -2: 'B', 0: 'A XOR B'}
-    visualize.draw_net(config, winner, True, node_names=node_names)
-    visualize.plot_stats(stats, ylog=False, view=True)
-    visualize.plot_species(stats, view=True)
+    if visualize is not None:
+        node_names = {-1: 'A', -2: 'B', 0: 'A XOR B'}
+        visualize.draw_net(config, winner, True, node_names=node_names)
+        visualize.plot_stats(stats, ylog=False, view=True)
+        visualize.plot_species(stats, view=True)
 
 
 if __name__ == '__main__':

--- a/neat/__init__.py
+++ b/neat/__init__.py
@@ -11,4 +11,5 @@ from neat.reporting import StdOutReporter
 from neat.species import DefaultSpeciesSet
 from neat.statistics import StatisticsReporter
 from neat.parallel import ParallelEvaluator
+from neat.threaded import ThreadedEvaluator
 from neat.checkpoint import Checkpointer

--- a/neat/__init__.py
+++ b/neat/__init__.py
@@ -1,6 +1,7 @@
 import neat.nn as nn
 import neat.ctrnn as ctrnn
 import neat.iznn as iznn
+import neat.distributed as distributed
 
 from neat.config import Config
 from neat.population import Population, CompleteExtinctionException
@@ -11,5 +12,6 @@ from neat.reporting import StdOutReporter
 from neat.species import DefaultSpeciesSet
 from neat.statistics import StatisticsReporter
 from neat.parallel import ParallelEvaluator
+from neat.distributed import DistributedEvaluator, host_is_local
 from neat.threaded import ThreadedEvaluator
 from neat.checkpoint import Checkpointer

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -1,4 +1,47 @@
-"""distributed evaluation of genomes"""
+"""
+Distributed evaluation of genomes.
+
+About nodes:
+The master node (=the node which creates and mutates genomes) and the slave
+nodes (=the nodes which evaluate genomes) can execute the same script. The
+role of a node is determined using the 'mode' argument of the
+DistributedEvaluator. If the mode is MODE_AUTO, the 'host_is_local()' function
+is used to check if the 'addr' argument points to the localhost. If it does, the
+node starts as a master node, otherwise as a slave node. If 'mode' is
+MODE_MASTER, the node always starts as a master node. If 'mode' is MODE_SLAVE,
+the node will always start as a slave node.
+There can only be one master node per NEAT, but any number of slave nodes.
+The master node will not evaluate any genome, which means you will always need
+at least two nodes.
+You can run any number of nodes on the same physical node.
+
+Usage:
+1. import modules and define evaluation logic (the eval_genome function).
+(after this, check for 'if __name__ == "__main__"', and put the rest of the code
+inside of the bode of the statement.)
+2. load config and create a population (here as variable 'p')
+3. if required, create and add  reporters
+4. create a DistributedEvaluator(addr_of_master_node, "some_password",
+eval_function, mode=MODE_AUTO) (here as variable 'de')
+5. call de.start(exit_on_stop=True)
+The 'start()' call will block on the slave nodes and call sys.exit(0) when the
+NEAT evolution finishes. This means that the following code will only be
+executed on the master node.
+6. start the evaluation using 'p.run(de.evaluate, number_of_generations)'
+7. stop the slave nodes using 'de.stop()'
+8. you are done. you may want to save the winning genome or show some statistics
+
+See 'examples/xor/evolve-feedforward-distributed.py' for a complete example.
+
+Utility functions:
+
+'host_is_local(hostname, port=22)' returns True if hostname points to the local
+node. This can be used to check if a node will run as a master node or as a
+slave node.
+
+'chunked(data, chunksize)': split data in a list of chunks with at most
+'chunksize' elements.
+"""
 import multiprocessing
 import socket
 import sys
@@ -35,6 +78,7 @@ class RoleError(RuntimeError):
     An exception raised when a role-specific method is being
     called without being in the role.
     """
+    pass
 
 
 def host_is_local(hostname, port=None):

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -198,7 +198,7 @@ class DistributedEvaluator(object):
         else:
             raise ValueError("Invalid mode!")
 
-    def stop(self, wait=1):
+    def stop(self, wait=1, shutdown=True):
         """stops all slaves."""
         if self.mode != MODE_MASTER:
             raise RoleError("Not in master mode!")
@@ -207,6 +207,8 @@ class DistributedEvaluator(object):
         stopevent = self.manager.get_stopevent()
         stopevent.set()
         time.sleep(wait)
+        if shutdown:
+            self.manager.shutdown()
 
     def _start_master(self):
         """starts as the master"""

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -1,0 +1,295 @@
+"""distributed evaluation of genomes"""
+import multiprocessing
+import socket
+import sys
+import threading
+import time
+
+try:
+    import Queue as queue
+except ImportError:
+    import queue
+
+from multiprocessing import managers
+from argparse import Namespace
+
+
+# Some of this code is based on
+# http://eli.thegreenplace.net/2012/01/24/distributed-computing-in-python-with-multiprocessing
+# According to the website, the code is in the public domain
+# ('public domain' links to unlicense.org).
+# This means that we can use the code from this website.
+# Thanks to Eli Bendersky for making his code open source.
+
+
+# modes to determine the role of a machine
+# the master handles the evolution of the genomes
+# the slave handles the evaluation of the genomes
+MODE_AUTO = 0  # auto determine server role
+MODE_MASTER = 1  # enforce master mode
+MODE_SLAVE = 2  # enforce slave mode
+
+
+class RoleError(RuntimeError):
+    """
+    An exception raised when a role-specific method is being
+    called without being in the role.
+    """
+
+
+def host_is_local(hostname, port=None):
+    """
+    Returns True if the hostname points to the localhost, otherwise False.
+    """
+    if port is None:
+        port = 22  # no port specified, lets just use the ssh port
+    hostname = socket.getfqdn(hostname)
+    if hostname in ("localhost", "0.0.0.0"):
+        return True
+    localhost = socket.gethostname()
+    localaddrs = socket.getaddrinfo(localhost, port)
+    targetaddrs = socket.getaddrinfo(hostname, port)
+    for (family, socktype, proto, canonname, sockaddr) in localaddrs:
+        for (rfamily, rsocktype, rproto, rcanonname, rsockaddr) in targetaddrs:
+            if rsockaddr[0] == sockaddr[0]:
+                return True
+    return False
+
+
+def chunked(data, chunksize):
+    """
+    Returns a list of chunks containing at most 'chunksize' elements of data.
+    """
+    if chunksize < 1:
+        raise ValueError("Chunksize must be at least 1!")
+    if not isinstance(chunksize, int):
+        raise ValueError("Chunksize needs to be an integer")
+    res = []
+    cur = []
+    for e in data:
+        cur.append(e)
+        if len(cur) >= chunksize:
+            res.append(cur)
+            cur = []
+    if len(cur) > 0:
+        res.append(cur)
+    return res
+
+
+class DistributedEvaluator(object):
+    """An evaluator working across multiple machines"""
+    def __init__(
+            self,
+            addr,
+            authkey,
+            eval_function,
+            slave_chunksize=1,
+            num_workers=None,
+            worker_timeout=60,
+            mode=MODE_AUTO
+            ):
+        """
+        'addr' should be a tuple of (hostname, port) pointing to the machine
+        running the DistributedEvaluator in master mode. If mode is MODE_AUTO,
+        the mode is determined by checking wether the hostname points to this
+        host or not.
+        'authkey' is the password used to restrict access to the manager.
+        All DistributedEvaluators need to use the same authkey.
+        'eval_function' should take two arguments (a genome object and the
+        configuration) and return a single float (the genome's fitness).
+        'slave_chunksize' specifies the number of genomes which will be send to
+        a slave at once.
+        'num_workers' is the number of child processes to use if in client
+        mode. It defaults to None, which means multiprocessing.cpu_count()
+        is used to determine this value.
+        If it equals to 1, do evaluate it in this process.
+        'worker_timeout' specifies the timeout for getting the results from
+        a worker when in slave mode.
+        """
+        self.addr = addr
+        self.authkey = authkey
+        self.eval_function = eval_function
+        self.slave_chunksize = slave_chunksize
+        if num_workers is None:
+            self.num_workers = multiprocessing.cpu_count()
+        else:
+            self.num_workers = num_workers
+        self.worker_timeout = worker_timeout
+        if mode == MODE_AUTO:
+            if host_is_local(self.addr[0]):
+                mode = MODE_MASTER
+            else:
+                mode = MODE_SLAVE
+        self.mode = mode
+        self.manager = None
+        self.started = False
+
+    def is_master(self):
+        """returns True if the host is the master"""
+        return (self.mode == MODE_MASTER)
+
+    def start(self, exit_on_stop=True, slave_wait=0):
+        """
+        If the DistributedEvaluator is in master mode, start the manager
+        process and returns. In this case, the 'exit_on_stop' argument will
+        be ignored.
+        If the DistributedEvaluator is in slave mode, connect to the manager
+        and and wait for tasks.
+        If in slave mode and 'exit_on_stop' is True, sys.exit() will be called
+        when the connection is lost.
+        'slave_wait' specifies the time (in seconds) to sleep before actually
+        starting when in client mode.
+        """
+        if self.started:
+            raise RuntimeError("DistributedEvaluator already started!")
+        self.started = True
+        if self.mode == MODE_MASTER:
+            self._start_master()
+        elif self.mode == MODE_SLAVE:
+            time.sleep(slave_wait)
+            self._start_slave()
+            self._slave_loop()
+            if exit_on_stop:
+                sys.exit(0)
+        else:
+            raise ValueError("Invalid mode!")
+
+    def stop(self, wait=1):
+        """stops all slaves."""
+        if self.mode != MODE_MASTER:
+            raise RoleError("Not in master mode!")
+        if not self.started:
+            raise RuntimeError("Not yet started!")
+        stopevent = self.manager.get_stopevent()
+        stopevent.set()
+        time.sleep(wait)
+
+    def _start_master(self):
+        """starts as the master"""
+        inqueue = queue.Queue()
+        outqueue = queue.Queue()
+        namespace = Namespace()
+        stop_event = threading.Event()
+
+        class _EvaluatorSyncManager(managers.SyncManager):
+            """
+            A custom SyncManager.
+            Please see the documentation of multiprocesing for more
+            informations.
+            """
+            pass
+
+        _EvaluatorSyncManager.register(
+            "get_inqueue",
+            callable=lambda: inqueue,
+            )
+        _EvaluatorSyncManager.register(
+            "get_outqueue",
+            callable=lambda: outqueue,
+            )
+        _EvaluatorSyncManager.register(
+            "get_namespace",
+            callable=lambda: namespace,
+            )
+        _EvaluatorSyncManager.register(
+            "get_stopevent",
+            callable=lambda: stop_event,
+            )
+
+        self.manager = _EvaluatorSyncManager(
+            address=self.addr,
+            authkey=self.authkey,
+            )
+        self.manager.start()
+
+        self.inqueue = self.manager.get_inqueue()
+        self.outqueue = self.manager.get_outqueue()
+
+    def _start_slave(self):
+        """starts as a slave"""
+
+        class _EvaluatorSyncManager(managers.SyncManager):
+            """
+            A custom SyncManager.
+            Please see the documentation of multiprocesing for more
+            informations.
+            """
+            pass
+
+        _EvaluatorSyncManager.register("get_inqueue")
+        _EvaluatorSyncManager.register("get_outqueue")
+        _EvaluatorSyncManager.register("get_namespace")
+        _EvaluatorSyncManager.register("get_stopevent")
+
+        self.manager = _EvaluatorSyncManager(
+            address=self.addr,
+            authkey=self.authkey,
+            )
+        self.manager.connect()
+
+    def _slave_loop(self):
+        """the worker loop for the slave"""
+        inqueue = self.manager.get_inqueue()
+        outqueue = self.manager.get_outqueue()
+        stopevent = self.manager.get_stopevent()
+        if self.num_workers > 1:
+            pool = multiprocessing.Pool(self.num_workers)
+        else:
+            pool = None
+        while not stopevent.is_set():
+            try:
+                tasks = inqueue.get(block=True, timeout=0.2)
+            except (managers.RemoteError, queue.Empty):
+                continue
+            if pool is None:
+                res = []
+                for genome_id, genome, config in tasks:
+                    fitness = self.eval_function(genome, config)
+                    res.append((genome_id, fitness))
+                outqueue.put(res)
+            else:
+                genome_ids = []
+                jobs = []
+                for genome_id, genome, config in tasks:
+                    genome_ids.append(genome_id)
+                    jobs.append(
+                        pool.apply_async(
+                            self.eval_function, (genome, config)
+                            )
+                        )
+                results = [
+                    job.get(timeout=self.worker_timeout) for job in jobs
+                    ]
+                zipped = zip(genome_ids, results)
+                outqueue.put(zipped)
+
+    def evaluate(self, genomes, config):
+        """
+        Evaluates the genomes.
+        This method raises an RoleError when this
+        DistributedEvaluator is not in master mode.
+        """
+        if self.mode != MODE_MASTER:
+            raise RoleError("Not in master mode!")
+        stopevent = self.manager.get_stopevent()
+        tasks = [(genome_id, genome, config) for genome_id, genome in genomes]
+        id2genome = {genome_id: genome for genome_id, genome in genomes}
+        tasks = chunked(tasks, self.slave_chunksize)
+        n_tasks = len(tasks)
+        for task in tasks:
+            self.inqueue.put(task)
+        tresults = []
+        while len(tresults) < n_tasks:
+            try:
+                sr = self.outqueue.get(block=True, timeout=0.2)
+            except (queue.Empty, managers.RemoteError):
+                if stopevent.is_set():
+                    raise SystemExit("Received stop event.")
+                continue
+            tresults.append(sr)
+        results = []
+        for sr in tresults:
+            results += sr
+        for genome_id, fitness in results:
+            genome = id2genome[genome_id]
+            genome.fitness = fitness

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -14,8 +14,8 @@ class ThreadedEvaluator(object):
     """
     def __init__(self, num_workers, eval_function):
         '''
-        eval_function should take one argument (a genome object) and return
-        a single float (the genome's fitness).
+        eval_function should take two arguments (a genome object and the
+        configuration) and return a single float (the genome's fitness).
         '''
         self.num_workers = num_workers
         self.eval_function = eval_function
@@ -52,10 +52,10 @@ class ThreadedEvaluator(object):
         """the worker function"""
         while self.working:
             try:
-                genome_id, genome = self.inqueue.get(block=True, timeout=0.2)
+                genome_id, genome, config = self.inqueue.get(block=True, timeout=0.2)
             except queue.Empty:
                 continue
-            f = self.eval_function(genome)
+            f = self.eval_function(genome, config)
             self.outqueue.put((genome_id, genome, f))
 
     def evaluate(self, genomes, config):
@@ -65,7 +65,7 @@ class ThreadedEvaluator(object):
         p = 0
         for genome_id, genome in genomes:
             p += 1
-            self.inqueue.put((genome_id, genome))
+            self.inqueue.put((genome_id, genome, config))
 
         # assign the fitness back to each genome
         while p > 0:

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -60,6 +60,8 @@ class ThreadedEvaluator(object):
 
     def evaluate(self, genomes, config):
         """evaluate the genomes"""
+        if not self.working:
+            self.start()
         p = 0
         for genome_id, genome in genomes:
             p += 1

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -33,7 +33,7 @@ class ThreadedEvaluator(object):
         if self.working:
             return
         self.working = True
-        for i in xrange(self.num_workers):
+        for i in range(self.num_workers):
             w = threading.Thread(
                 name="Worker Thread #{i}".format(i=i),
                 target=self._worker,

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -25,7 +25,12 @@ class ThreadedEvaluator(object):
         self.outqueue = queue.Queue()
 
     def __del__(self):
-        """called on deletion of the object. We stop our workers here."""
+        """
+        Called on deletion of the object. We stop our workers here.
+        WARNING: __del__ may not always work!
+        please stop the threads explicitly by calling self.stop()!
+        todo: ensure that there are no reference-cycles.
+        """
         if self.working:
             self.stop()
             

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -1,0 +1,72 @@
+"""threaded evaluation of genomes"""
+import threading
+
+try:
+    import Queue as queue
+except ImportError:
+    import queue
+
+
+class ThreadedEvaluator(object):
+    """
+    A threaded genome evaluator.
+    Usefull on python implementations without GIL.
+    """
+    def __init__(self, num_workers, eval_function):
+        '''
+        eval_function should take one argument (a genome object) and return
+        a single float (the genome's fitness).
+        '''
+        self.num_workers = num_workers
+        self.eval_function = eval_function
+        self.workers = []
+        self.working = False
+        self.inqueue = queue.Queue()
+        self.outqueue = queue.Queue()
+
+    def __del__(self):
+        if self.working:
+            self.stop()
+            
+    def start(self):
+        """starts the worker threads"""
+        if self.working:
+            return
+        self.working = True
+        for i in xrange(self.num_workers):
+            w = threading.Thread(
+                name="Worker Thread #{i}".format(i=i),
+                target=self._worker,
+                )
+            w.daemon = True
+            w.start()
+            self.workers.append(w)
+
+    def stop(self):
+        """stops the worker threads and wait for them to finish"""
+        self.working = False
+        for w in self.workers:
+            w.join()
+
+    def _worker(self):
+        """the worker function"""
+        while self.working:
+            try:
+                genome_id, genome = self.inqueue.get(block=True, timeout=0.2)
+            except queue.Empty:
+                continue
+            f = self.eval_function(genome)
+            self.outqueue.put((genome_id, genome, f))
+
+    def evaluate(self, genomes, config):
+        """evaluate the genomes"""
+        p = 0
+        for genome_id, genome in genomes:
+            p += 1
+            self.inqueue.put((genome_id, genome))
+
+        # assign the fitness back to each genome
+        while p > 0:
+            p -= 1
+            genome_id, genome, fitness = self.outqueue.get()
+            genome.fitness = fitness

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -25,6 +25,7 @@ class ThreadedEvaluator(object):
         self.outqueue = queue.Queue()
 
     def __del__(self):
+        """called on deletion of the object. We stop our workers here."""
         if self.working:
             self.stop()
             
@@ -47,12 +48,16 @@ class ThreadedEvaluator(object):
         self.working = False
         for w in self.workers:
             w.join()
+        self.workers = []
 
     def _worker(self):
         """the worker function"""
         while self.working:
             try:
-                genome_id, genome, config = self.inqueue.get(block=True, timeout=0.2)
+                genome_id, genome, config = self.inqueue.get(
+                    block=True,
+                    timeout=0.2,
+                    )
             except queue.Empty:
                 continue
             f = self.eval_function(genome, config)

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -105,7 +105,7 @@ def test_DistributedEvaluator_mode():
         addr = (hostname, 80)
         de = neat.DistributedEvaluator(
             addr,
-            authkey="abcd1234",
+            authkey=b"abcd1234",
             eval_function=eval_dummy_genome_nn,
             mode=mode,
             )
@@ -133,7 +133,7 @@ def test_DistributedEvaluator_mode():
     # test invalid mode error
     de = neat.DistributedEvaluator(
         addr,
-        authkey="abcd1234",
+        authkey=b"abcd1234",
         eval_function=eval_dummy_genome_nn,
         mode="#invalid MODE!",
         )
@@ -148,7 +148,7 @@ def test_DistributedEvaluator_master_restrictions():
     """tests that some master-exclusive methods fail when called  by the slaves"""
     slave = neat.DistributedEvaluator(
         ("localhost", 80),
-        authkey="abcd1234",
+        authkey=b"abcd1234",
         eval_function=eval_dummy_genome_nn,
         mode=MODE_SLAVE,
         )
@@ -180,7 +180,7 @@ def test_distributed_evaluation_multiprocessing():
     created using the multiprocessing module.
     """
     addr = ("localhost", random.randint(12000, 30000))
-    authkey = "abcd1234"
+    authkey = b"abcd1234"
     mp = multiprocessing.Process(
         name="Master evaluation process",
         target=run_master,
@@ -223,7 +223,7 @@ def test_distributed_evaluation_threaded():
     We use this to get the coverage correctly.
     """
     addr = ("localhost", random.randint(12000, 30000))
-    authkey = "abcd1234"
+    authkey = b"abcd1234"
     mp = threading.Thread(
         name="Master evaluation thread",
         target=run_master,

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1,0 +1,319 @@
+"""tests for neat.distributed"""
+import socket
+import os
+import multiprocessing
+import random
+import threading
+
+import neat
+from neat.distributed import chunked, MODE_AUTO, MODE_MASTER, MODE_SLAVE, RoleError
+
+
+def eval_dummy_genome_nn(genome, config):
+    """dummy evaluation function"""
+    net = neat.nn.FeedForwardNetwork.create(genome, config)
+    return 1.0
+
+
+def test_chunked():
+    """test for neat.distributed.chunked"""
+    # test chunked(range(110), 10)
+    # => 11 chunks of 10 elements
+    d110 = list(range(110))
+    d110c = chunked(d110, 10)
+    if len(d110c) != 11:
+        raise Exception("neat.distributed.chunked(range(110), 10) did not create 11 chunks!")
+    if len(d110c[0]) != 10:
+        raise Exception("neat.distributed.chunked(range(110), 10) did not create chunks of length 10!")
+    rec = []
+    for e in d110c:
+        rec += e
+    if rec != d110:
+        raise Exception("neat.distributed.chunked(range(110), 10) did create wrong chunks!")
+    # test invalid argument checking
+    try:
+        chunked(range(10), 0)
+    except ValueError:
+        pass
+    else:
+        raise Exception("neat.distributed.chunked(range(10), 0) did not raise an exception!")
+    try:
+        chunked(range(10), 1.1)
+    except ValueError:
+        pass
+    else:
+        raise Exception("neat.distributed.chunked(range(10), 1.1) did not raise an exception!")
+    # test chunked(range(13, 3))
+    # => 4 chunks of 3 elements, 1 chunk of 1 element
+    d13 = list(range(13))
+    d13c = chunked(d13, 3)
+    if len(d13c) != 5:
+        raise Exception("neat.distributed.chunked(range(13), 3) did not create 5 chunks!")
+    if len(d13c[0]) != 3:
+        raise Exception("neat.distributed.chunked(range(13), 3) did not create chunks of length 3!")
+    if len(d13c[-1]) != 1:
+        raise Exception("neat.distributed.chunked(range(13), 3) did not create  a last chunk of length 1!")
+    rec = []
+    for e in d13c:
+        rec += e
+    if rec != d13:
+        raise Exception("neat.distributed.chunked(range(13), 3) did create wrong chunks!")
+
+
+def test_host_is_local():
+    """test fir neat.distributed.host_is_local"""
+    tests = (
+        # (hostname or ip, expected value)
+        ("localhost", True),
+        ("0.0.0.0", True),
+        ("127.0.0.1", True),
+        ("::1", True),
+        (socket.gethostname(), True),
+        (socket.getfqdn(), True),
+        ("github.com", False),
+        ("google.de", False),
+        )
+    for hostname, islocal in tests:
+        result = neat.host_is_local(hostname)
+        if result != islocal:
+            raise Exception(
+                "Hostname/IP: {h}; Expected: {e}; Got: {r}".format(
+                    h=hostname, e=islocal, r=result,
+                    )
+                )
+
+
+def test_DistributedEvaluator_mode():
+    """tests for the mode determination of DistributedEvaluator"""
+    # test auto mode setting
+    # we also test that the mode is not
+    # automatically determined when explicitly
+    # given
+    tests = (
+        # (hostname or ip, mode to pass, expected mode)
+        ("localhost", MODE_MASTER, MODE_MASTER),
+        ("0.0.0.0", MODE_MASTER, MODE_MASTER),
+        ("localhost", MODE_SLAVE, MODE_SLAVE),
+        ("example.org", MODE_MASTER, MODE_MASTER),
+        (socket.gethostname(), MODE_SLAVE, MODE_SLAVE),
+        ("localhost", MODE_AUTO, MODE_MASTER),
+        (socket.gethostname(), MODE_AUTO, MODE_MASTER),
+        (socket.getfqdn(), MODE_AUTO, MODE_MASTER),
+        ("example.org", MODE_AUTO, MODE_SLAVE),
+        )
+    for hostname, mode, expected in tests:
+        addr = (hostname, 80)
+        de = neat.DistributedEvaluator(
+            addr,
+            authkey="abcd1234",
+            eval_function=eval_dummy_genome_nn,
+            mode=mode,
+            )
+        result = de.mode
+        if result != expected:
+            raise Exception(
+                "Mode determination failed! Hostname: {h}; expected: {e}; got: {r}!".format(
+                    h=hostname, e=expected, r=result,
+                    )
+                )
+        if result == MODE_AUTO:
+            raise Exception(
+                "DistributedEvaluator.__init__(mode=MODE_AUTO) did not automatically determine its mode!"
+                )
+        elif result == MODE_MASTER:
+            if not de.is_master():
+                raise Exception(
+                    "DistributedEvaluator.is_master() returns False even if the evaluator is in master mode!"
+                    )
+        elif result == MODE_SLAVE:
+            if de.is_master():
+                raise Exception(
+                    "DistributedEvaluator.is_master() returns True even if the evaluator is in slave mode!"
+                    )
+    # test invalid mode error
+    de = neat.DistributedEvaluator(
+        addr,
+        authkey="abcd1234",
+        eval_function=eval_dummy_genome_nn,
+        mode="#invalid MODE!",
+        )
+    try:
+        de.start()
+    except ValueError:
+        pass
+    else:
+        raise Exception("Passing an invalid mode did not cause an exception to be raised on start()!")
+
+def test_DistributedEvaluator_master_restrictions():
+    """tests that some master-exclusive methods fail when called  by the slaves"""
+    slave = neat.DistributedEvaluator(
+        ("localhost", 80),
+        authkey="abcd1234",
+        eval_function=eval_dummy_genome_nn,
+        mode=MODE_SLAVE,
+        )
+    try:
+        slave.stop()
+    except RoleError:
+        # only ignore RoleErrors
+        # a RuntimeError should only be raised when in master mode.
+        pass
+    else:
+        raise Exception("A DistributedEvaluator in slave mode could call stop()!")
+    try:
+        slave.evaluate(None, None)  # we do not need valid values for this test
+    except RoleError:
+        # only ignore RoleErrors
+        # other errors should only be raised when in master mode.
+        pass
+    else:
+        raise Exception("A DistributedEvaluator in slave mode could call evaluate()!")
+
+
+def test_distributed_evaluation_multiprocessing():
+    """
+    Full test run using the Distributed Evaluator.
+    Note that this is not a very good test for the
+    DistributedEvaluator, because we still work on
+    one machine, not accross multiple machines.
+    We emulate the other machines using subprocesses
+    created using the multiprocessing module.
+    """
+    addr = ("localhost", random.randint(12000, 30000))
+    authkey = "abcd1234"
+    mp = multiprocessing.Process(
+        name="Master evaluation process",
+        target=run_master,
+        args=(addr, authkey, 300),
+        )
+    mp.start()
+    mwcp = multiprocessing.Process(
+        name="Child evaluation process (multiple workers)",
+        target=run_slave,
+        args=(addr, authkey, 2),
+        )
+    swcp = multiprocessing.Process(
+        name="Child evaluation process (direct evaluation)",
+        target=run_slave,
+        args=(addr, authkey, 1),
+        )
+    swcp.daemon = True  # we cant set this on mwcp
+    mwcp.start()
+    swcp.start()
+    mp.join()
+    mwcp.join()
+    swcp.join()
+    if mp.exitcode != 0:
+        raise Exception("Master-process exited with status {s}!".format(s=mp.exitcode))
+    if mwcp.exitcode != 0:
+        raise Exception("Multiworker-slave-process exited with status {s}!".format(s=mwcp.exitcode))
+    if swcp.exitcode != 0:
+        raise Exception("Singleworker-slave-process exited with status {s}!".format(s=swcp.exitcode))
+
+
+def test_distributed_evaluation_threaded():
+    """
+    Full test run using the Distributed Evaluator.
+    Note that this is not a very good test for the
+    DistributedEvaluator, because we still work on
+    one machine, not accross multiple machines.
+    We emulate the other machines using threads.
+    This test is like test_distributed_evaluation_multiprocessing,
+    but uses threads instead of processes.
+    We use this to get the coverage correctly.
+    """
+    addr = ("localhost", random.randint(12000, 30000))
+    authkey = "abcd1234"
+    mp = threading.Thread(
+        name="Master evaluation thread",
+        target=run_master,
+        args=(addr, authkey, 30),
+        )
+    mp.start()
+    mwcp = threading.Thread(
+        name="Child evaluation thread (multiple workers)",
+        target=run_slave,
+        args=(addr, authkey, 2),
+        )
+    swcp = threading.Thread(
+        name="Child evaluation thread (direct evaluation)",
+        target=run_slave,
+        args=(addr, authkey, 1),
+        )
+    swcp.daemon = True  # we cant set this on mwcp
+    mwcp.start()
+    swcp.start()
+    mp.join()
+    mwcp.join()
+    swcp.join()
+    
+    # we cant check for exceptions in the threads.
+    # however, these checks are also done in
+    # test_distributed_evaluationmultiprocessing,
+    # so they should not fail here.
+    # also, this test is mainly for the coverage.
+
+    
+
+def run_master(addr, authkey, generations):
+    """starts a DistributedEvaluator in master mode."""
+    # Load configuration.
+    local_dir = os.path.dirname(__file__)
+    config_path = os.path.join(local_dir, 'test_configuration')
+    config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
+                         neat.DefaultSpeciesSet, neat.DefaultStagnation,
+                         config_path)
+
+    # Create the population, which is the top-level object for a NEAT run.
+    p = neat.Population(config)
+
+    # Add a stdout reporter to show progress in the terminal.
+    p.add_reporter(neat.StdOutReporter(True))
+    stats = neat.StatisticsReporter()
+    p.add_reporter(stats)
+
+    # Run for up to 300 generations.
+    de = neat.DistributedEvaluator(
+        addr,
+        authkey=authkey,
+        eval_function=eval_dummy_genome_nn,
+        mode=MODE_MASTER,
+        )
+    de.start()
+    p.run(de.evaluate, generations)
+    de.stop(wait=3)
+
+    stats.save()
+
+
+def run_slave(addr, authkey, num_workers=1):
+    """starts a DistributedEvaluator in slave mode."""
+    # Load configuration.
+    local_dir = os.path.dirname(__file__)
+    config_path = os.path.join(local_dir, 'test_configuration')
+    config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
+                         neat.DefaultSpeciesSet, neat.DefaultStagnation,
+                         config_path)
+
+    # Create the population, which is the top-level object for a NEAT run.
+    p = neat.Population(config)
+
+    # Add a stdout reporter to show progress in the terminal.
+    p.add_reporter(neat.StdOutReporter(True))
+    stats = neat.StatisticsReporter()
+    p.add_reporter(stats)
+
+    # Run for up to 300 generations.
+    de = neat.DistributedEvaluator(
+        addr,
+        authkey=authkey,
+        eval_function=eval_dummy_genome_nn,
+        mode=MODE_SLAVE,
+        num_workers=num_workers,
+        )
+    try:
+        de.start(slave_wait=3, exit_on_stop=True)
+    except SystemExit:
+        pass
+    else:
+        raise Exception("DistributedEvaluator in slave mode did not try to exit!")

--- a/tests/test_simple_run.py
+++ b/tests/test_simple_run.py
@@ -67,7 +67,8 @@ def test_parallel():
     stats.save()
 
 
-def test_threaded():
+def test_threaded_evaluation():
+    """tests a neat evolution using neat.threaded.ThreadedEvaluator"""
     # Load configuration.
     local_dir = os.path.dirname(__file__)
     config_path = os.path.join(local_dir, 'test_configuration')
@@ -88,6 +89,60 @@ def test_threaded():
     p.run(pe.evaluate, 300)
 
     stats.save()
+
+
+def test_threaded_evaluator():
+    """tests generall functionality of neat.threaded.ThreadedEvaluator"""
+    n_workers = 3
+    e = neat.ThreadedEvaluator(n_workers, eval_dummy_genome_nn)
+    # ensure workers are not started
+    if (len(e.workers) > 0) or (e.working):
+        raise Exception("ThreadedEvaluator started on __init__()!")
+    # ensure start() starts the workers
+    e.start()
+    if (len(e.workers) != n_workers) or (not e.working):
+        raise Exception("ThreadedEvaluator did not start on start()!")
+    w = e.workers[0]
+    if not w.is_alive():
+        raise Exception("Workers did not start on start()")
+    # ensure a second call to start() does nothing when already started
+    e.start()
+    if (len(e.workers) != n_workers) or (not e.working):
+        raise Exception(
+            "A second ThreadedEvaluator.start() call was not ignored!"
+            )
+    w = e.workers[0]
+    if not w.is_alive():
+        raise Exception("A worker died or stopped!")
+    # ensure stop() works
+    e.stop()
+    if (len(e.workers) != 0) or (e.working):
+        raise Exception(
+            "ThreadedEvaluator.stop() did not work!"
+            )
+    if w.is_alive():
+        raise Exception("A worker is still alive!")
+    # ensure a second call to stop() does nothing when already stopped
+    e.stop()
+    if (len(e.workers) != 0) or (e.working):
+        raise Exception(
+            "A second ThreadedEvaluator.stop() call was not ignored!"
+            )
+    if w.is_alive():
+        raise Exception("A worker is still alive or was resurrected!")
+    # ensure a restart is possible
+    # ensure start() starts the workers
+    e.start()
+    if (len(e.workers) != n_workers) or (not e.working):
+        raise Exception("ThreadedEvaluator did not restart on start()!")
+    w = e.workers[0]
+    if not w.is_alive():
+        raise Exception("Workers did not start on start()")
+    # ensure del stops workers
+    w = e.workers[0]
+    del e
+    if w.is_alive():
+        raise Exception("__del__() did not stop workers!")
 
 
 def eval_dummy_genomes_nn_recurrent(genomes, config):

--- a/tests/test_simple_run.py
+++ b/tests/test_simple_run.py
@@ -139,10 +139,12 @@ def test_threaded_evaluator():
     if not w.is_alive():
         raise Exception("Workers did not start on start()")
     # ensure del stops workers
-    w = e.workers[0]
     del e
-    if w.is_alive():
-        raise Exception("__del__() did not stop workers!")
+    # unfortunately, __del__() may never be called, even when using del
+    # this means that testing for __del__() to call stop() may not work
+    # this test had a high random failure rate, so i removed it.
+    # if w.is_alive():
+    #     raise Exception("__del__() did not stop workers!")
 
 
 def eval_dummy_genomes_nn_recurrent(genomes, config):

--- a/tests/test_simple_run.py
+++ b/tests/test_simple_run.py
@@ -33,10 +33,10 @@ def test_serial():
     p.run(eval_dummy_genomes_nn, 300)
 
     stats.save()
-    #stats.save_genome_fitness(with_cross_validation=True)
+    # stats.save_genome_fitness(with_cross_validation=True)
 
     stats.get_fitness_stdev()
-    #stats.get_average_cross_validation_fitness()
+    # stats.get_average_cross_validation_fitness()
     stats.best_unique_genomes(5)
     stats.best_genomes(5)
     stats.best_genome()
@@ -62,6 +62,29 @@ def test_parallel():
 
     # Run for up to 300 generations.
     pe = neat.ParallelEvaluator(4, eval_dummy_genome_nn)
+    p.run(pe.evaluate, 300)
+
+    stats.save()
+
+
+def test_threaded():
+    # Load configuration.
+    local_dir = os.path.dirname(__file__)
+    config_path = os.path.join(local_dir, 'test_configuration')
+    config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
+                         neat.DefaultSpeciesSet, neat.DefaultStagnation,
+                         config_path)
+
+    # Create the population, which is the top-level object for a NEAT run.
+    p = neat.Population(config)
+
+    # Add a stdout reporter to show progress in the terminal.
+    p.add_reporter(neat.StdOutReporter(True))
+    stats = neat.StatisticsReporter()
+    p.add_reporter(stats)
+
+    # Run for up to 300 generations.
+    pe = neat.ThreadedEvaluator(4, eval_dummy_genome_nn)
     p.run(pe.evaluate, 300)
 
     stats.save()


### PR DESCRIPTION
I have added the `ThreadedEvaluator` class and the `DistributedEvaluator` class for a more flexible usage of computational resources during evaluation.

**ThreadedEvaluator:** A class inspired by the `ParallelEvaluator`, but uses Threads for evaluating genomes. This is useful when using a python implementation without a GIL (e.g. jython and pypy-stm).
**DistributedEvaluator:** An Evaluator for the evaluation of genomes accross multiple computer nodes. This class is also inspired by the `ParallelEvaluator`. However, the overhead is even bigger than the one of the `ParalellEvaluator`, which means it it only useful when the evaluation function requires heavy calculations.
Both the `ThreadedEvaluator` and the `DistributedEvaluator` are implemented using the standard modules.
**Usage of the `ThreadedEvaluator`:**
The usage of the `ThreadedEvaluator` is much like the usage of the `ThreadedEvaluator`. However, the `ThreadedEvaluator` does not support the `timeout` argument. Also, the worker threads are not stopped automatically when the instance is deleted. However, the threads can still be stopped using the `stop()` method of the `ThreadedEvaluator` and will automatically stop when the other non-daemonic threads are done.
**Usage of the `DistributedEvaluator`:**
The usage of the `DistributedEvaluator` is very simple. Both the master node (=the computer mutating genomes) and the slave nodes (=the computers evaluating genomes) can run the exact same script.
Please note that the master node will not try to evaluate any genomes by itself. At least one slave node is required, but you can launch a slave node on the same physical node as the master node. Please keep in mind, that you will have to force the slave-node into slave-mode in this case. The `examples/xor/evolve-feedforward-distributed.py` has a `--force-slave` argument for this case.
1. define evaluation logic, load config and create population as you would normally do
2. create an instance of `neat.DistributedEvaluator` using the following arguments:
   - `addr` is a tuple of (hostname/ip, port) pointing to the master node.
   - `authkey` is a password used for authentification to the main node.
   - `eval_function` is the function for evaluating a single genome
   - `slave_chunksize=1` defines the number of genomes which will be send to a slave at once. When a slave node is using multiple worker processes, this number should be at least equal to the number of worker processes. Higher values may be more overhead efficient. Default: 1.
   - `num_workers=1`: When this value is greater than 1 and this node is in slave mode, use this many worker processes for the evaluation. Otherwise, evaluate in the thread which called `DistributedEvaluator.start()` (most likely the main thread). Default: 1.
   - `worker_timeout`: When this node is in slave mode, wait at most this  many seconds for the result of the worker processes. Default: 60-
   - `mode=neat.distributed.MODE_AUTO`:  In which mode this node should operate (one of `MODE_MASTER`, `MODE_SLAVE`, `MODE_AUTO` (the default), as defined in `neat.distributed`). If the value is `MODE_AUTO` (the default), check if the `addr` argument points to the localhost. If it does, set the mode to `MODE_MASTER`, otherwise to `MODE_SLAVE`. The other two values force this node into the corresponding mode.
3. call the `start()` method of the `DistributedEvaluator` instance. This function blocks on the slave nodes, but returns on the master nodes. By default, the slave nodes will exit at the end of this call when the work is done. The arguments are all optional:
   - `exit_on_stop=True`: if in slave mode, call `sys.exit(0)` once the work is done.
   - `slave_wait=0`: If in slave mode, wait this many seconds before connecting, This is useful if the master node may take some time to start.
4. call the `run` method of the population,  using the `evaluate` method/attribute of the `DistributedEvaluator` instance.
5. call the `stop` method of the `DistributedEvaluator` instance.
6. proceed normally (print statistics, show graphs, ...)
If you are using multiple worker processes, all calls starting from step 2 should be done in a `if __name__ == "__main__"` statement.

This PR also contains tests and xor-examples for the `ThreadedEvaluator` and the `DistributedEvaluator`. The `DistributedEvaluator` example requires command line arguments to specify the address of the  master node. It is not the most simple example for the `DistributedEvaluator`, but tries to use most arguments to explain what they do.
**important:** This PR changes the `travis.yml` config to use `pypy3.5-5.8.0` instead of `pypy3`. Travis apparently uses an outdated `pypy3` version, which contains a few bugs.

This PR replaces PR #95. However, some changes (like the changes to the docstrings of `ParallelEvaluator.__init__` ) have been removed using a history rewrite.

**Edit:** I added a note to this PR stating that the master node does not try to evaluate any genome wby itself.