### PR TITLE
neat.distributed: use socket module instead of multiprocessing.managers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ install:
     - pip install --upgrade nose coveralls coverage
     - if [[ $TRAVIS_PYTHON_VERSION == 'pypy'* ]]; then export TRAVIS_WAIT=45; else export TRAVIS_WAIT=20; fi
 script:
-    travis_wait "${TRAVIS_WAIT}" nosetests --with-coverage --cover-package=neat -vd
+    nosetests --with-coverage --cover-package=neat -vd
 after_success:
     coveralls

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -352,30 +352,6 @@ class DistributedEvaluator(object):
         self._va_lock = threading.Lock()  # lock to prevent parallel access to some vars
         self._stopwaitevent = threading.Event()  # event for waiting for the network thread to stop
 
-    '''
-    def __reduce__(self):
-        """part of the pickle protocol."""
-        return (
-            self.__class__._load_from_pickle,
-            (self.addr. self.authkey, self.eval_function, self.secondary_chunksize. self.slave_chunksize, self.num_workers, self.worker_timeout, self.mode),
-            )
-
-    @classmethod
-    def _load_from_pickle(cls, *args):
-        """called to create an instance of this class from pickle."""
-        ins = cls(*args)
-        return ins
-    def __getstate__(self):
-        """Required by the pickle protocol."""
-        # we do not actually save any state, but we need __getstate__ to be
-        # called.
-        return True  # return some nonzero value
-
-    def __setstate__(self, state):
-        """Called when instances of this class are unpickled."""
-        self._listen_s = None
-    '''
-
     def is_primary(self):
         """Returns True if the caller is the primary node"""
         return (self.mode == MODE_PRIMARY)
@@ -560,10 +536,6 @@ class DistributedEvaluator(object):
                             # unknown message; this is probably an error.
                             self._remove_client(s)
                             break
-
-            # for s in to_write:
-            #    # not required
-            #    pass
 
             for s in has_err:
                 if s is self._listen_s:

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -353,6 +353,19 @@ class DistributedEvaluator(object):
         self._va_lock = threading.Lock()  # lock to prevent parallel access to some vars
         self._stopwaitevent = threading.Event()  # event for waiting for the network thread to stop
 
+    def __reduce__(self):
+        """part of the pickle protocol."""
+        return (
+            self.__class__._load_from_pickle,
+            (self.addr. self.authkey, self.eval_function, self.secondary_chunksize. self.slave_chunksize, self.num_workers, self.worker_timeout, self.mode),
+            )
+
+    @classmethod
+    def _load_from_pickle(cls, *args):
+        """called to create an instance of this class from pickle."""
+        ins = this.__class__(*args)
+        return ins
+    '''
     def __getstate__(self):
         """Required by the pickle protocol."""
         # we do not actually save any state, but we need __getstate__ to be
@@ -361,7 +374,8 @@ class DistributedEvaluator(object):
 
     def __setstate__(self, state):
         """Called when instances of this class are unpickled."""
-        pass
+        self._listen_s = None
+    '''
 
     def is_primary(self):
         """Returns True if the caller is the primary node"""

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -126,28 +126,29 @@ def host_is_local(hostname, port=22): # no port specified, just use the ssh port
     """
     Returns True if the hostname points to the localhost, otherwise False.
     """
-    hostname = socket.getfqdn(hostname)
-    if hostname in (
-        # for py2/py3 compatibility, check for both binary and native strings
-        b"localhost", "localhost",
-        b"0.0.0.0", "0.0.0.0",
-        b"127.0.0.1", "127.0.0.1",
-        b"1.0.0.127.in-addr.arpa", "1.0.0.127.in-addr.arpa",
-        b"1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa",
-        "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa"
-        ):
-        return True
-    localhost = socket.gethostname()
-    if hostname == localhost:
-        return True
-    localaddrs = socket.getaddrinfo(localhost, port)
-    targetaddrs = socket.getaddrinfo(hostname, port)
-    for (ignored_family, ignored_socktype, ignored_proto, ignored_canonname,
-         sockaddr) in localaddrs:
-        for (ignored_rfamily, ignored_rsocktype, ignored_rproto,
-             ignored_rcanonname, rsockaddr) in targetaddrs:
-            if rsockaddr[0] == sockaddr[0]:
-                return True
+    hostnames = [hostname, socket.getfqdn(hostname)]
+    for hn in hostnames:
+        if hn in (
+            # for py2/py3 compatibility, check for both binary and native strings
+            b"localhost", "localhost",
+            b"0.0.0.0", "0.0.0.0",
+            b"127.0.0.1", "127.0.0.1",
+            b"1.0.0.127.in-addr.arpa", "1.0.0.127.in-addr.arpa",
+            b"1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa",
+            "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa"
+            ):
+            return True
+        localhost = socket.gethostname()
+        if hn == localhost:
+            return True
+        localaddrs = socket.getaddrinfo(localhost, port)
+        targetaddrs = socket.getaddrinfo(hn, port)
+        for (ignored_family, ignored_socktype, ignored_proto, ignored_canonname,
+             sockaddr) in localaddrs:
+            for (ignored_rfamily, ignored_rsocktype, ignored_rproto,
+                 ignored_rcanonname, rsockaddr) in targetaddrs:
+                if rsockaddr[0] == sockaddr[0]:
+                    return True
     return False
 
 

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -459,7 +459,7 @@ class DistributedEvaluator(object):
         self._stopwaitevent.clear()  # just to be sure
         while self.started:
             to_check_read = [self._listen_s] + list(self._clients.keys())  # list() for python3 compatibility
-            to_check_err = [self._listen_s] + list(self._clients.keys())  #  ^^ TODO: is there another way to do this? 
+            to_check_err = [self._listen_s] + list(self._clients.keys())  #  ^^ TODO: is there another way to do this?
             to_read, to_write, has_err = select.select(to_check_read, [], to_check_err, 0.1)
             if (len(to_read) + len(to_write) + len(has_err)) == 0:
                 continue
@@ -496,7 +496,7 @@ class DistributedEvaluator(object):
                             self._remove_client(s)
                             break
                         action = loaded.get("action", None)
-                        
+
                         # authentication
                         if action == "auth":
                             authkey = loaded.get("authkey")
@@ -577,7 +577,7 @@ class DistributedEvaluator(object):
         # stop connected clients
         forced = (self._state == _STATE_FORCED_SHUTDOWN)
         try:
-            for s in self._clients.keys():
+            for s in list(self._clients.keys()):  # list() for py3 compatibility
                 self._send_stop(s, forced=forced)
                 self._remove_client(s)
         finally:
@@ -707,7 +707,7 @@ class DistributedEvaluator(object):
                     results = [
                         job.get(timeout=self.worker_timeout) for job in jobs
                         ]
-                    res = zip(genome_ids, results)
+                    res = list(zip(genome_ids, results))  # list() for py3 compatibility
                 try:
                     self._send_results(res)
                 except (socket.error, EOFError, IOError, OSError, socket.gaierror):
@@ -734,13 +734,13 @@ class DistributedEvaluator(object):
         while True:
             msg = json_bytes_loads(self._mh.get_message())
             action = msg.get("action", None)
-            
+
             if action == "stop":
                 forced = msg.get("forced", False)
                 if forced:
                     self._should_reconnect = False
                 return None
-                
+
             elif action == "tasks":
                 tasks = msg.get("tasks", None)
                 if tasks is not None:

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -127,8 +127,8 @@ def host_is_local(hostname, port=22): # no port specified, just use the ssh port
     Returns True if the hostname points to the localhost, otherwise False.
     """
     hostname = socket.getfqdn(hostname)
-    if hostname in ("localhost", "0.0.0.0", "127.0.0.1", "1.0.0.127.in-addr.arpa",
-                    "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa"):
+    if hostname in (b"localhost", b"0.0.0.0", b"127.0.0.1", b"1.0.0.127.in-addr.arpa",
+                    b"1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa"):
         return True
     localhost = socket.gethostname()
     if hostname == localhost:

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -127,8 +127,15 @@ def host_is_local(hostname, port=22): # no port specified, just use the ssh port
     Returns True if the hostname points to the localhost, otherwise False.
     """
     hostname = socket.getfqdn(hostname)
-    if hostname in (b"localhost", b"0.0.0.0", b"127.0.0.1", b"1.0.0.127.in-addr.arpa",
-                    b"1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa"):
+    if hostname in (
+        # for py2/py3 compatibility, check for both binary and native strings
+        b"localhost", "localhost",
+        b"0.0.0.0", "0.0.0.0",
+        b"127.0.0.1", "127.0.0.1",
+        b"1.0.0.127.in-addr.arpa", "1.0.0.127.in-addr.arpa",
+        b"1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa",
+        "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa"
+        ):
         return True
     localhost = socket.gethostname()
     if hostname == localhost:
@@ -157,7 +164,7 @@ def _determine_mode(addr, mode):
     elif type(addr) == type(b"binary_string"):
         host = addr
     else:
-        raise TypeError("'addr' needs to be a tuple or an bytestring!")
+        raise TypeError("'addr' needs to be a tuple or an bytestring (instead got {a!r})!".format(a=addr))
     if mode == MODE_AUTO:
         if host_is_local(host):
             return MODE_PRIMARY

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -121,6 +121,7 @@ class AuthError(Exception):
     """raised if the Authentication failed."""
     pass
 
+
 def host_is_local(hostname, port=22): # no port specified, just use the ssh port
     """
     Returns True if the hostname points to the localhost, otherwise False.

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -126,7 +126,12 @@ def host_is_local(hostname, port=22): # no port specified, just use the ssh port
     """
     Returns True if the hostname points to the localhost, otherwise False.
     """
-    hostnames = [hostname, socket.getfqdn(hostname)]
+    try:
+        fqdn = socket.getfqdn(hostname)
+    except TypeError:
+        # sometimes fails on pypy3
+        fqdn = None
+    hostnames = [hostname, fqdn]
     for hn in hostnames:
         if hn in (
             # for py2/py3 compatibility, check for both binary and native strings

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -487,17 +487,17 @@ class DistributedEvaluator(object):
                         except:
                             self._remove_client(s)
                             break
-                        action = loaded.get(b"action", None)
+                        action = loaded.get("action", None)
                         
                         # authentication
-                        if action == b"auth":
-                            authkey = loaded.get(b"authkey")
+                        if action == "auth":
+                            authkey = loaded.get("authkey")
                             if authkey == self.authkey:
                                 if s not in self._authenticated_clients:
                                     self._authenticated_clients.append(s)
-                                mh.send_json({b"action": "auth_response", b"success": True})
+                                mh.send_json({"action": "auth_response", "success": True})
                             else:
-                                mh.send_json({b"action": b"auth_response", b"success": False})
+                                mh.send_json({"action": "auth_response", "success": False})
                                 self._remove_client(s)
                                 break
                         elif s not in self._authenticated_clients:
@@ -506,7 +506,7 @@ class DistributedEvaluator(object):
                             break
                         
                         # taks distribution
-                        elif action == b"get_task":
+                        elif action == "get_task":
                             try:
                                 tasks = self._inqueue.get(timeout=0)
                             except queue.Empty:
@@ -517,8 +517,8 @@ class DistributedEvaluator(object):
                                 self._send_tasks(mh, tasks)
                         
                         # results
-                        elif action == b"results":
-                            results = loaded.get(b"results", None)
+                        elif action == "results":
+                            results = loaded.get("results", None)
                             if results is not None:
                                 self._outqueue.put(results)
                                 self._va_lock.acquire()

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -98,6 +98,7 @@ _STATE_ERROR = 3
 _LENGTH_PREFIX = "!Q"
 _LENGTH_PREFIX_LENGTH = struct.calcsize(_LENGTH_PREFIX)
 _DEFAULT_NETWORK_ENCODING = "utf-8"  # encoding for json messages
+_DEFAULT_PICKLE_ENCODING = "latin1"  # encoding for pickle
 
 
 class ModeError(RuntimeError):
@@ -210,13 +211,12 @@ def json_bytes_loads(bytestr):
 
 def _serialize_tasks(tasks):
     """serialize a tasklist."""
-    # TODO: this needs to be done in a more efficient way.
-    return base64.b64encode(pickle.dumps(tasks, -1))
+    return pickle.dumps(tasks, -1).decode(_DEFAULT_PICKLE_ENCODING)
 
 
 def _load_tasks(s):
     """loads a tasklist from a string returned by _serialize_tasks()"""
-    return pickle.loads(base64.b64decode(s))
+    return pickle.loads(s.encode(_DEFAULT_PICKLE_ENCODING))
 
 
 class _MessageHandler(object):

--- a/neat/distributed.py
+++ b/neat/distributed.py
@@ -56,23 +56,23 @@ a primary node or as a secondary node with MODE_AUTO.
 from __future__ import print_function
 
 import socket
+import select
+import struct
 import sys
 import time
 import warnings
+import multiprocessing
+import base64
+import pickle
+import json
+import threading
 
-# below still needed for queue.Empty
 try:
-    # pylint: disable=import-error
     import Queue as queue
 except ImportError:
-    # pylint: disable=import-error
     import queue
 
-import multiprocessing
-from multiprocessing import managers
-from argparse import Namespace
-
-# Some of this code is based on
+# Some of the original code is based on
 # http://eli.thegreenplace.net/2012/01/24/distributed-computing-in-python-with-multiprocessing
 # According to the website, the code is in the public domain
 # ('public domain' links to unlicense.org).
@@ -91,6 +91,12 @@ MODE_SECONDARY = MODE_SLAVE = 2  # enforce secondary mode
 _STATE_RUNNING = 0
 _STATE_SHUTDOWN = 1
 _STATE_FORCED_SHUTDOWN = 2
+_STATE_ERROR = 3
+
+
+# constants for network communication
+_LENGTH_PREFIX = "!Q"
+_LENGTH_PREFIX_LENGTH = struct.calcsize(_LENGTH_PREFIX)
 
 
 class ModeError(RuntimeError):
@@ -101,6 +107,18 @@ class ModeError(RuntimeError):
     """
     pass
 
+
+class ProtocolError(IOError):
+    """
+    An Exception raised when either the client or the server does not
+    send a valid response.
+    """
+    pass
+
+
+class AuthError(Exception):
+    """raised if the Authentication failed."""
+    pass
 
 def host_is_local(hostname, port=22): # no port specified, just use the ssh port
     """
@@ -169,155 +187,91 @@ def chunked(data, chunksize):
     return res
 
 
-class _ExtendedManager(object):
-    """A class for managing the multiprocessing.managers.SyncManager"""
-    __safe_for_unpickling__ = True  # this may not be safe for unpickling,
-                                    # but this is required by pickle.
+def _serialize_tasks(tasks):
+    """serialize a tasklist."""
+    # TODO: this needs to be done in a more efficient way.
+    return base64.b64encode(pickle.dumps(tasks, -1))
 
-    def __init__(self, addr, authkey, mode, start=False):
-        self.addr = addr
-        self.authkey = authkey
-        self.mode = _determine_mode(addr, mode)
-        self.manager = None
-        self._secondary_state= multiprocessing.managers.Value(int, _STATE_RUNNING)
-        if start:
-            self.start()
 
-    def __reduce__(self):
+def _load_tasks(s):
+    """loads a tasklist from a string returned by _serialize_tasks()"""
+    return pickle.loads(base64.b64decode(s))
+
+
+class _MessageHandler(object):
+    """
+    Class for managing a socket connection.
+    This includes detecting incomplete messages and completing them with
+    later messages.
+    """
+    
+    # constants for managing the current state
+    _STATE_RECV_PREFIX = 0  # we are currently waiting for the length prefix
+    _STATE_RECV_MESSAGE = 1  # we arer currently receiving a message
+    
+    def __init__(self, s):
+        self._s = s
+        self._state = self._STATE_RECV_PREFIX
+        self._msg_size = _LENGTH_PREFIX_LENGTH
+        self._cur_buff = ""
+        self.messages = []
+    
+    def feed(self, data):
         """
-        This method is used by pickle to serialize instances of this class.
+        Process received data.
+        Returns the number which still need to be received for this message.
         """
-        return (
-            self.__class__,
-            (self.addr, self.authkey, self.mode, True),
-            )
-
-    def start(self):
-        """Starts or connects to the manager."""
-        if self.mode == MODE_PRIMARY:
-            i = self._start()
+        received_a_whole_message = False
+        self._cur_buff += data
+        while len(self._cur_buff) >= self._msg_size:
+            msg = self._cur_buff[:self._msg_size]
+            self._cur_buff = self._cur_buff[self._msg_size:]
+            received_a_whole_message = received_a_whole_message or (len(self._cur_buff) >= self._msg_size)
+            self._handle_message(msg)
+        if received_a_whole_message:
+            return 0
         else:
-            i = self._connect()
-        self.manager = i
-
-    def stop(self):
-        """Stops the manager."""
-        self.manager.shutdown()
-
-    def set_secondary_state(self, value):
-        """Sets the value for 'secondary_state'."""
-        if value not in (_STATE_RUNNING, _STATE_SHUTDOWN, _STATE_FORCED_SHUTDOWN):
-            raise ValueError(
-                "State {!r} is invalid - needs to be one of _STATE_RUNNING, _STATE_SHUTDOWN, or _STATE_FORCED_SHUTDOWN".format(
-                    value)
-                )
-        if self.manager is None:
-            raise RuntimeError("Manager not started")
-        self.manager.set_state(value)
-
-    def _get_secondary_state(self):
-        """
-        Returns the value for 'secondary_state'.
-        This is required for the manager.
-        """
-        return self._secondary_state
-
-    def _get_manager_class(self, register_callables=False):
-        """
-        Returns a new 'Manager' subclass with registered methods.
-        If 'register_callable' is True, defines the 'callable' arguments.
-        """
-
-        class _EvaluatorSyncManager(managers.BaseManager):
-            """
-            A custom BaseManager.
-            Please see the documentation of `multiprocessing` for more
-            information.
-            """
-            pass
-
-        inqueue = queue.Queue()
-        outqueue = queue.Queue()
-        namespace = Namespace()
-
-        if register_callables:
-            _EvaluatorSyncManager.register(
-                "get_inqueue",
-                callable=lambda: inqueue,
-                )
-            _EvaluatorSyncManager.register(
-                "get_outqueue",
-                callable=lambda: outqueue,
-                )
-            _EvaluatorSyncManager.register(
-                "get_state",
-                callable=self._get_secondary_state,
-                )
-            _EvaluatorSyncManager.register(
-                "set_state",
-                callable=lambda v: self._secondary_state.set(v),
-                )
-            _EvaluatorSyncManager.register(
-                "get_namespace",
-                callable=lambda: namespace,
-                )
-
-
+            return self._msg_size - len(self._cur_buff)
+    
+    def _handle_message(self, msg):
+        """handle an incomming message as required by self._state"""
+        if self._state == self._STATE_RECV_PREFIX:
+            self._msg_size = struct.unpack(_LENGTH_PREFIX, msg)[0]
+            self._state = self._STATE_RECV_MESSAGE
+        elif self._state == self._STATE_RECV_MESSAGE:
+            self._msg_size = _LENGTH_PREFIX_LENGTH
+            self._state = self._STATE_RECV_PREFIX
+            self.messages.append(msg)
         else:
-            _EvaluatorSyncManager.register(
-                "get_inqueue",
-                )
-            _EvaluatorSyncManager.register(
-                "get_outqueue",
-                )
-            _EvaluatorSyncManager.register(
-                "get_state",
-                )
-            _EvaluatorSyncManager.register(
-                "set_state",
-                )
-            _EvaluatorSyncManager.register(
-                "get_namespace",
-                )
-        return _EvaluatorSyncManager
+            raise RuntimeError("Internal error: invalid state!")
+    
+    def send_message(self, msg):
+        """sends a message."""
+        length = len(msg)
+        prefix = struct.pack(_LENGTH_PREFIX, length)
+        data = prefix + length
+        self._s.send(data)
+    
+    def send_json(self, d):
+        """serializes d into json, then sends the message."""
+        ser = json.dumps(d)
+        return self.send_message(ser)
+    
+    def recv(self):
+        """receives a message from the socket (blocking)."""
+        to_recv = 1  # receive one byte initialy
+        while True:
+            data = self._s.recv(to_recv)
+            to_recv = self.feed(data)
+            if to_recv == 0:
+                return
+    
+    def get_message(self):
+        """if a message was received, return it. Otherwise, receive a message and return it."""
+        while len(self.messages) == 0:
+            self.recv()
+        return self.messages.pop(0)
 
-    def _connect(self):
-        """Connects to the manager."""
-        cls = self._get_manager_class(register_callables=False)
-        ins = cls(address=self.addr, authkey=self.authkey)
-        ins.connect()
-        return ins
-
-    def _start(self):
-        """Starts the manager."""
-        cls = self._get_manager_class(register_callables=True)
-        ins = cls(address=self.addr, authkey=self.authkey)
-        ins.start()
-        return ins
-
-    @property
-    def secondary_state(self):
-        """Whether the secondary nodes should still process elements."""
-        v = self.manager.get_state()
-        return v.get()
-
-    def get_inqueue(self):
-        """Returns the inqueue."""
-        if self.manager is None:
-            raise RuntimeError("Manager not started")
-        return self.manager.get_inqueue()
-
-    def get_outqueue(self):
-        """Returns the outqueue."""
-        if self.manager is None:
-            raise RuntimeError("Manager not started")
-        return self.manager.get_outqueue()
-
-    def get_namespace(self):
-        """Returns the namespace."""
-        if self.manager is None:
-            raise RuntimeError("Manager not started")
-        return self.manager.get_namespace()
 
 
 class DistributedEvaluator(object):
@@ -358,7 +312,7 @@ class DistributedEvaluator(object):
         self.authkey = authkey
         self.eval_function = eval_function
         self.secondary_chunksize = secondary_chunksize
-        self.slave_chunksize = secondary_chunksize # backward compatibility
+        self.slave_chunksize = secondary_chunksize  # backwards compatibility
         if num_workers:
             self.num_workers = num_workers
         else:
@@ -370,11 +324,11 @@ class DistributedEvaluator(object):
                 self.num_workers = 1
         self.worker_timeout = worker_timeout
         self.mode = _determine_mode(self.addr, mode)
-        self.em = _ExtendedManager(self.addr, self.authkey, mode=self.mode, start=False)
-        self.inqueue = None
-        self.outqueue = None
-        self.namespace = None
         self.started = False
+        self._inqueue = queue.Queue()
+        self._outqueue = queue.Queue()
+        self._sock_thread = None
+        self._va_lock = threading.Lock()
 
     def __getstate__(self):
         """Required by the pickle protocol."""
@@ -384,7 +338,7 @@ class DistributedEvaluator(object):
 
     def __setstate__(self, state):
         """Called when instances of this class are unpickled."""
-        self._set_shared_instances()
+        pass
 
     def is_primary(self):
         """Returns True if the caller is the primary node"""
@@ -439,38 +393,244 @@ class DistributedEvaluator(object):
         if not self.started:
             raise RuntimeError("Not yet started!")
         if force_secondary_shutdown:
-            state = _STATE_FORCED_SHUTDOWN
+            self._state = _STATE_FORCED_SHUTDOWN
         else:
-            state = _STATE_SHUTDOWN
-        self.em.set_secondary_state(state)
-        time.sleep(wait)
+            self._state = _STATE_SHUTDOWN
+        time.sleep(wait)  # wait is now mostly for backwards compability
         if shutdown:
-            self.em.stop()
+            try:
+                self._listen_s.close()
+            except:
+                pass
         self.started = False
-        self.inqueue = self.outqueue = self.namespace = None
 
     def _start_primary(self):
         """Start as the primary"""
-        self.em.start()
-        self.em.set_secondary_state(_STATE_RUNNING)
-        self._set_shared_instances()
+        # setup primary specific vars
+        self._clients = {}  # socket -> _MessageHandler
+        self._s2tasks = {}  # socket -> tasks
+        self._authenticated_clients = []  # list of authenticated secondaries
+        self._waiting_clients = []  # list of secondaries waiting for tasks
+        
+        # create socket, bind and listen
+        self._bind_and_listen()
+        
+        # create and start network thread
+        self._sock_thread = threading.Thread(
+            name="{c} network thread".format(c=self.__class__),
+            target=self._primary_sock_thread,
+            )
+        self._sock_thread.start()
+    
+    def _bind_and_listen(self):
+        """create a socket, bind it and starts listening for connections."""
+        self._listen_s = socket.socket(family=socket.AF_INET, type=socket.SOCK_STREAM)  # todo: ipv6 support
+        self._listen_s.bind(self.addr)
+        self._listen_s.listen(3)
+    
+    def _primary_sock_thread(self):
+        """method for the socket thread of the primary node."""
+        if self.mode != MODE_PRIMARY:
+            raise ModeError("Not a primary node!")
+        while self._started:
+            to_check_read = [self._listen_s, self._clients.keys()]
+            to_check_err = [self._listen_s, self._clients.keys()]
+            to_read, to_write, has_err = select.select(to_check_read, [], to_check_err, 0.1)
+            if (len(to_read) + len(to_write) + len(has_err)) == 0:
+                continue
+            
+            for s in to_read:
+                if s is self._listen_s:
+                    # new connection
+                    c, addr = s.accept()
+                    mh = _MessageHandler(c)
+                    self._clients[c] = mh
+                else:
+                    # data available
+                    data = s.recv(4096)  # receive at most 4k bytes. If more are available, recv them in the next iteration.
+                    mh = self._clients.get(s, None)
+                    if mh is None:
+                        self._remove_client(s)
+                        continue
+                    mh.feed(data)
+                    
+                    while len(mh.messages) > 0:
+                        msg = mh.messages.pop(0)
+                        try:
+                            loaded = json.loads(msg)
+                        except:
+                            self._remove_client(s)
+                            break
+                        action = loaded.get(b"action", None)
+                        
+                        # authentication
+                        if action == b"auth":
+                            authkey = loaded.get(b"authkey")
+                            if authkey == self.authkey:
+                                if s not in self._authenticated_clients:
+                                    self._authenticated_clients.append(s)
+                                mh.send_json({b"action": "auth_response", "state": b"success"})
+                            else:
+                                mh.send_json({b"action": b"auth_response", b"state": b"error"})
+                                self._remove_client(s)
+                                break
+                        elif s not in self._authentiated_clients:
+                            # client did not authenticate
+                            self._remove_client(s)
+                            break
+                        
+                        # taks distribution
+                        elif action == b"get_task":
+                            try:
+                                tasks = self._inqueue.get(timeout=0)
+                            except queue.Empty:
+                                self._va_lock.acquire()
+                                self._waiting_clients.append(s)
+                                self._va_lock.release()
+                            else:
+                                self._send_tasks(mh, tasks)
+                        
+                        # results
+                        elif action == b"results":
+                            results = msg.get(b"results", None)
+                            if results is not None:
+                                self.outqueue.put(results)
+                                self._va_lock.acquire()
+                                if s in self._s2tasks:
+                                    del self._s2tasks[s]
+                                self._va_lock.release()
+                            else:
+                                # results not send; reissue tasks if required.
+                                self._va_lock.acquire()
+                                if s in self._s2tasks:
+                                    tasks = self._s2tasks[s]
+                                    del self._s2tasks[s]
+                                self._va_lock.release()
+                                self.inqueue.put(tasks)
+                        
+                        else:
+                            # unknown message; this is probably an error.
+                            self._remove_client(s)
+                            break
+            
+            # for s in to_write:
+            #    # not required
+            #    pass
+            
+            for s in has_err:
+                if s is self._listen_s:
+                    # cant listen anymore
+                    # try to rebind
+                    try:
+                        s.close()
+                    except:
+                        # ignore exception during socket close,
+                        # socket may already be closed.
+                        pass
+                    if self._state == self._STATE_RUNNING:
+                        try:
+                            self._bind_and_listen()
+                        except:
+                            self._state = self._STATE_ERROR
+                            break
+                    else:
+                        # server stopped or not yet started,
+                        # do not rebind and break this loop instead.
+                        break
+                else:
+                    self._remove_client(s)
+        
+        # stop connected clients
+        forced = (self._state == self._STATE_FORCED_SHUTDOWN)
+        for s in self._clients:
+            self._send_stop(s, forced=forced)
+            self._remove_client(s)
+    
+    def _remove_client(self, s):
+        """closes and removes the client."""
+        self._va_lock.acquire()
+        try:
+            s.close()
+        except:
+            pass
+        if s in self._clients:
+            del self._clients[s]
+        if s in self._authenticated_clients:
+            self._authenticated_clients.remove(s)
+        if s in self._s2tasks:
+            tasks = self._s2tasks[s]
+            del self._s2tasks[s]
+        else:
+            tasks = None
+        self._va_lock.release()
+        if tasks is not None:
+            self._add_tasks(tasks)
+    
+    def _send_tasks(self, mh, tasks):
+        """sends some tasks to a secondary connected through the message handler mh."""
+        ser_tasks = _serialize_tasks(tasks)
+        mh.send_json(
+               {
+                   b"action": b"tasks",
+                   b"tasks": ser_tasks,
+               },
+           )
+    
+    def _send_stop(self, s, forced=False):
+        """sends a stop message to a client."""
+        self._va_lock.acquire()
+        mh = self._clients.get(s, _MessageHandler(s))
+        mh.send_json(
+                {
+                    b"action": b"stop",
+                    "forced": forced,
+                }
+            )
+        self._va_lock.release()
+     
+    def _add_tasks(self, tasks):
+        """adds a task for evaluation."""
+        if len(self._waiting_clients) > 0:
+            self._va_lock.acquire()
+            s = self._waiting_clients.pop(0)
+            mh = self._clients.get(s, None)
+            self._va_lock.release()
+            if mh is None:
+                self._remove_client(s)
+                return self._add_tasks(tasks)
+            self._send_tasks(mh, tasks)
+        else:
+            self._inqueue.put(tasks)
 
     def _start_secondary(self):
         """Start as a secondary."""
-        self.em.start()
-        self._set_shared_instances()
-
-    def _set_shared_instances(self):
-        """Sets attributes from the shared instances."""
-        self.inqueue = self.em.get_inqueue()
-        self.outqueue = self.em.get_outqueue()
-        self.namespace = self.em.get_namespace()
-
-    def _reset_em(self):
-        """Resets self.em and the shared instances."""
-        self.em = _ExtendedManager(self.addr, self.authkey, mode=self.mode, start=False)
-        self.em.start()
-        self._set_shared_instances()
+        # TODO: implement this
+        pass
+    
+    def _reset(self):
+        """resets the internal state of the secondary nodes."""
+        # connect
+        self._s = socket.socket(family=socket.AF_INET, type=socket.SOCK_STREAM)
+        self._s.connect(self.addr)
+        
+        # create a _MessageHandler
+        self._mh = _MessageHandler(self._s)
+        
+        # auth
+        self._mh.send_json(
+                {
+                    b"action": b"auth",
+                    b"authkey": self.authkey,
+                }
+            )
+        response = json.loads(self._mh.get_message())
+        if response.get(b"action", None) != b"auth_response":
+            self._s.close()
+            raise ProtocolError("Server did not send an auth response!")
+        success = response.get(b"success", False)
+        if not success:
+            self._s.close()
+            raise AuthError("Invalid authkey!")
 
     def _secondary_loop(self, reconnect=False):
         """The worker loop for the secondary nodes."""
@@ -478,45 +638,20 @@ class DistributedEvaluator(object):
             pool = multiprocessing.Pool(self.num_workers)
         else:
             pool = None
-        should_reconnect = True
-        while should_reconnect:
-            i = 0
+        self._should_reconnect = True
+        while self._should_reconnect:
             running = True
             try:
-                self._reset_em()
-            except (socket.error, EOFError, IOError, OSError, socket.gaierror, TypeError):
+                self._reset()
+            except (socket.error, EOFError, IOError, OSError, socket.gaierror,):
                 continue
             while running:
-                i += 1
-                if i % 5 == 0:
-                    # for better performance, only check every 5 cycles
-                    try:
-                        state = self.em.secondary_state
-                    except (socket.error, EOFError, IOError, OSError, socket.gaierror, TypeError):
-                        if not reconnect:
-                            raise
-                        else:
-                            break
-                    if state == _STATE_FORCED_SHUTDOWN:
-                        running = False
-                        should_reconnect = False
-                    elif state == _STATE_SHUTDOWN:
-                        running = False
-                    if not running:
-                        continue
                 try:
-                    tasks = self.inqueue.get(block=True, timeout=0.2)
-                except queue.Empty:
-                    continue
-                except (socket.error, EOFError, IOError, OSError, socket.gaierror, TypeError):
-                    break
-                except (managers.RemoteError, multiprocessing.ProcessError) as e:
-                    if ('Empty' in repr(e)) or ('TimeoutError' in repr(e)):
-                        continue
-                    if (('EOFError' in repr(e)) or ('PipeError' in repr(e)) or
-                        ('AuthenticationError' in repr(e))): # Second for Python 3.X, Third for 3.6+
+                    tasks = self._get_tasks()
+                    if tasks is None:
                         break
-                    raise
+                except (socket.error, EOFError, IOError, OSError, socket.gaierror):
+                    break
                 if pool is None:
                     res = []
                     for genome_id, genome, config in tasks:
@@ -537,22 +672,49 @@ class DistributedEvaluator(object):
                         ]
                     res = zip(genome_ids, results)
                 try:
-                    self.outqueue.put(res)
-                except (socket.error, EOFError, IOError, OSError, socket.gaierror, TypeError):
+                    self._send_results(res)
+                except (socket.error, EOFError, IOError, OSError, socket.gaierror):
                     break
-                except (managers.RemoteError, multiprocessing.ProcessError) as e:
-                    if ('Empty' in repr(e)) or ('TimeoutError' in repr(e)):
-                        continue
-                    if (('EOFError' in repr(e)) or ('PipeError' in repr(e)) or
-                        ('AuthenticationError' in repr(e))): # Second for Python 3.X, Third for 3.6+
-                        break
-                    raise
 
             if not reconnect:
-                should_reconnect = False
+                self._should_reconnect = False
                 break
+        try:
+            self._s.close()
+        except:
+            pass
         if pool is not None:
             pool.terminate()
+    
+    def _get_tasks(self):
+        """
+        Receives some tasks from the primary.
+        This method returns either the received tasks or None if the
+        secondary was stopped by the primary.
+        """
+        while True:
+            msg = json.loads(self._mh.get_message())
+            action = msg.get(b"action", None)
+            
+            if action == b"stop":
+                forced = msg.get("forced", False)
+                if forced:
+                    self._should_reconnect = False
+                return None
+                
+            elif action == b"tasks":
+                tasks = msg.get(b"tasks", None)
+                if tasks is not None:
+                    return _load_tasks(tasks)
+    
+    def _send_results(self, results):
+        """sends the results to the primary node."""
+        self._mh.send_json(
+                {
+                    b"action": b"results",
+                    b"results": results,
+                }
+            )
 
     def evaluate(self, genomes, config):
         """
@@ -566,13 +728,13 @@ class DistributedEvaluator(object):
         id2genome = {genome_id: genome for genome_id, genome in genomes}
         tasks = chunked(tasks, self.secondary_chunksize)
         n_tasks = len(tasks)
-        for task in tasks:
-            self.inqueue.put(task)
+        for tasklist in tasks:
+            self._add_tasks(tasklist)
         tresults = []
         while len(tresults) < n_tasks:
             try:
                 sr = self.outqueue.get(block=True, timeout=0.2)
-            except (queue.Empty, managers.RemoteError):
+            except (queue.Empty):
                 continue
             tresults.append(sr)
         results = []

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -77,7 +77,6 @@ def test_host_is_local():
         ("localhost", True),
         ("0.0.0.0", True),
         ("127.0.0.1", True),
-        #("::1", True), # depends on IP, etc setup on host to work right
         (socket.gethostname(), True),
         (socket.getfqdn(), True),
         ("github.com", False),
@@ -206,7 +205,6 @@ def test_DistributedEvaluator_primary_restrictions():
         raise Exception("A DistributedEvaluator in secondary mode could call evaluate()!")
 
 
-# @unittest.skipIf(ON_PYPY, "This test fails on pypy during travis builds but usually works locally.")
 def test_distributed_evaluation_multiprocessing(do_mwcp=True):
     """
     Full test run using the Distributed Evaluator (fake nodes using processes).
@@ -274,7 +272,6 @@ def test_distributed_evaluation_multiprocessing(do_mwcp=True):
             swcp.terminate()
 
 
-# @unittest.skipIf(ON_PYPY, "Pypy has problems with threading.")
 def test_distributed_evaluation_threaded():
     """
     Full test run using the Distributed Evaluator (fake nodes using threads).

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -182,7 +182,7 @@ def test_json_bytes_dumps_loads():
 def test_DistributedEvaluator_primary_restrictions():
     """Tests that some primary-exclusive methods fail when called by the secondaries"""
     secondary = neat.DistributedEvaluator(
-        ("localhost", 8022),
+        (b"localhost", 8022),
         authkey=u"abcd1234",
         eval_function=eval_dummy_genome_nn,
         mode=MODE_SECONDARY,
@@ -214,7 +214,7 @@ def test_distributed_evaluation_multiprocessing(do_mwcp=True):
     We emulate the other machines using subprocesses
     created using the multiprocessing module.
     """
-    addr = ("localhost", random.randint(12000, 30000))
+    addr = (b"localhost", random.randint(12000, 30000))
     authkey = u"abcd1234"
     mp = multiprocessing.Process(
         name="Primary evaluation process",
@@ -276,7 +276,7 @@ def test_distributed_evaluation_multiprocessing(do_mwcp=True):
 
 def test_distributed_evaluation_invalid_authkey_multiprocessing(pc=multiprocessing.Process):
     """Test for DistributedEvaluator-behavior on invalid authkey (Fake nodes using processes)"""
-    addr = ("localhost", random.randint(12000, 30000))
+    addr = (b"localhost", random.randint(12000, 30000))
     valid_authkey = u"Linux>Windows"
     invalid_authkey = u"Windows>Linux"
     print("[distributed] Tests/Process-control: starting primary node/thread...")
@@ -321,7 +321,7 @@ def test_distributed_evaluation_threaded():
     """
     if not HAVE_THREADING:
         raise unittest.SkipTest("Platform does not have threading")
-    addr = ("localhost", random.randint(12000, 30000))
+    addr = (b"localhost", random.randint(12000, 30000))
     authkey = u"abcd1234"
     mp = threading.Thread(
         name="Primary evaluation thread",

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -181,6 +181,7 @@ def test_DistributedEvaluator_primary_restrictions():
     else:
         raise Exception("A DistributedEvaluator in secondary mode could call evaluate()!")
 
+'''
 def test_DistributedEvaluator_state_error1():
     """Tests that attempts to use an unstarted manager for set_secondary_state cause an error."""
     primary = neat.DistributedEvaluator(
@@ -257,6 +258,7 @@ def test_DistributedEvaluator_state_error5():
     else:
         raise Exception("primary.em.set_secondary_state(-1) did not raise a ValueError!")
     
+'''
 
 @unittest.skipIf(ON_PYPY, "This test fails on pypy during travis builds but usually works locally.")
 def test_distributed_evaluation_multiprocessing(do_mwcp=True):

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -168,6 +168,7 @@ def test_json_bytes_dumps_loads():
     {"one": 1, "two": 2, "three": "three"},
     {"1": 2, "3":4, "5":6},
     u"unicode_string",
+    "native_string",
     ]
     bytestype = type(b"some bytestring")
     for obj in test_objs:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -117,7 +117,7 @@ def test_DistributedEvaluator_mode():
         try:
             de = neat.DistributedEvaluator(
                 addr,
-                authkey=b"abcd1234",
+                authkey="abcd1234",
                 eval_function=eval_dummy_genome_nn,
                 mode=mode,
                 )
@@ -399,6 +399,7 @@ def run_secondary(addr, authkey, num_workers=1):
         print("[distributed] secondary: expected a SystemExit; not SystemExit caught!")
         sys.stdout.flush()
         raise Exception("DistributedEvaluator in secondary mode did not try to exit!")
+
 
 if __name__ == '__main__':
     test_chunked()

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -181,86 +181,8 @@ def test_DistributedEvaluator_primary_restrictions():
     else:
         raise Exception("A DistributedEvaluator in secondary mode could call evaluate()!")
 
-'''
-def test_DistributedEvaluator_state_error1():
-    """Tests that attempts to use an unstarted manager for set_secondary_state cause an error."""
-    primary = neat.DistributedEvaluator(
-        ("localhost", 8022),
-        authkey=b"abcd1234",
-        eval_function=eval_dummy_genome_nn,
-        mode=MODE_PRIMARY,
-        )
-    try:
-        primary.em.set_secondary_state(_STATE_RUNNING)
-    except RuntimeError:
-        pass
-    else:
-        raise Exception("primary.em.set_secondary_state with unstarted manager did not raise a RuntimeError!")
 
-def test_DistributedEvaluator_state_error2():
-    """Tests that attempts to use an unstarted manager for get_inqueue cause an error."""
-    primary = neat.DistributedEvaluator(
-        ("localhost", 8022),
-        authkey=b"abcd1234",
-        eval_function=eval_dummy_genome_nn,
-        mode=MODE_PRIMARY,
-        )
-    try:
-        ignored = primary.em.get_inqueue()
-    except RuntimeError:
-        pass
-    else:
-        raise Exception("primary.em.get_inqueue() with unstarted manager did not raise a RuntimeError!")
-
-def test_DistributedEvaluator_state_error3():
-    """Tests that attempts to use an unstarted manager for get_outqueue cause an error."""
-    primary = neat.DistributedEvaluator(
-        ("localhost", 8022),
-        authkey=b"abcd1234",
-        eval_function=eval_dummy_genome_nn,
-        mode=MODE_PRIMARY,
-        )
-    try:
-        ignored = primary.em.get_outqueue()
-    except RuntimeError:
-        pass
-    else:
-        raise Exception("primary.em.get_outqueue() with unstarted manager did not raise a RuntimeError!")
-
-def test_DistributedEvaluator_state_error4():
-    """Tests that attempts to use an unstarted manager for get_namespace cause an error."""
-    primary = neat.DistributedEvaluator(
-        ("localhost", 8022),
-        authkey=b"abcd1234",
-        eval_function=eval_dummy_genome_nn,
-        mode=MODE_PRIMARY,
-        )
-    try:
-        ignored = primary.em.get_namespace()
-    except RuntimeError:
-        pass
-    else:
-        raise Exception("primary.em.get_namespace() with unstarted manager did not raise a RuntimeError!")
-
-def test_DistributedEvaluator_state_error5():
-    """Tests that attempts to set an invalid state cause an error."""
-    primary = neat.DistributedEvaluator(
-        ("localhost", 8022),
-        authkey=b"abcd1234",
-        eval_function=eval_dummy_genome_nn,
-        mode=MODE_PRIMARY,
-        )
-    primary.start()
-    try:
-        primary.em.set_secondary_state(-1)
-    except ValueError:
-        pass
-    else:
-        raise Exception("primary.em.set_secondary_state(-1) did not raise a ValueError!")
-    
-'''
-
-@unittest.skipIf(ON_PYPY, "This test fails on pypy during travis builds but usually works locally.")
+# @unittest.skipIf(ON_PYPY, "This test fails on pypy during travis builds but usually works locally.")
 def test_distributed_evaluation_multiprocessing(do_mwcp=True):
     """
     Full test run using the Distributed Evaluator (fake nodes using processes).
@@ -325,7 +247,7 @@ def test_distributed_evaluation_multiprocessing(do_mwcp=True):
             swcp.terminate()
 
 
-@unittest.skipIf(ON_PYPY, "Pypy has problems with threading.")
+# @unittest.skipIf(ON_PYPY, "Pypy has problems with threading.")
 def test_distributed_evaluation_threaded():
     """
     Full test run using the Distributed Evaluator (fake nodes using threads).

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -90,7 +90,7 @@ def test_host_is_local():
                                                                                           islocal))
             raise
         else: # if do not want to do 'raise' above for some cases
-            assert result == islocal, "Hostname/IP: {h}; Expected: {e}; Got: {r!r}".format(
+            assert result == islocal, "Unexpected results for hostname/IP: {h}; Expected: {e}; Got: {r!r}".format(
                 h=hostname, e=islocal, r=result)
 
 
@@ -105,10 +105,10 @@ def test_DistributedEvaluator_mode():
         (b"0.0.0.0", MODE_PRIMARY, MODE_PRIMARY),
         (b"localhost", MODE_SECONDARY, MODE_SECONDARY),
         (b"example.org", MODE_PRIMARY, MODE_PRIMARY),
-        (socket.gethostname(), MODE_SECONDARY, MODE_SECONDARY),
+        (socket.gethostname().encode("ascii"), MODE_SECONDARY, MODE_SECONDARY),
         (b"localhost", MODE_AUTO, MODE_PRIMARY),
-        (socket.gethostname(), MODE_AUTO, MODE_PRIMARY),
-        (socket.getfqdn(), MODE_AUTO, MODE_PRIMARY),
+        (socket.gethostname().encode("ascii"), MODE_AUTO, MODE_PRIMARY),
+        (socket.getfqdn().encode("ascii"), MODE_AUTO, MODE_PRIMARY),
         (b"example.org", MODE_AUTO, MODE_SECONDARY),
         )
     for hostname, mode, expected in tests:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -145,7 +145,7 @@ def test_DistributedEvaluator_mode():
     try:
         de = neat.DistributedEvaluator(
             addr,
-            authkey=b"abcd1234",
+            authkey=u"abcd1234",
             eval_function=eval_dummy_genome_nn,
             mode="#invalid MODE!",
         )
@@ -156,11 +156,34 @@ def test_DistributedEvaluator_mode():
         raise Exception("Passing an invalid mode did not cause an exception to be raised on start()!")
 
 
+def test_json_bytes_dumps_loads():
+    """
+    Test for the json_bytes_dumps() and json_bytes_loads() functions.
+    """
+    test_objs = [
+    1,
+    2,
+    3,
+    [1, 2, 3],
+    {"one": 1, "two": 2, "three": "three"},
+    {"1": 2, "3":4, "5":6},
+    u"unicode_string",
+    ]
+    bytestype = type(b"some bytestring")
+    for obj in test_objs:
+        dumped = neat.distributed.json_bytes_dumps(obj)
+        if type(dumped) != bytestype:
+            raise Exception("neat.distributed.json_bytes_dumps({o}) did not return a bytestring!".format(o=repr(obj)))
+        loaded = neat.distributed.json_bytes_loads(dumped)
+        if loaded != obj:
+            raise Exception("neat.distributed.json_bytes_loads(): {lo}; expected: {o}!".format(lo=repr(loaded), o=repr(obj)))
+
+
 def test_DistributedEvaluator_primary_restrictions():
     """Tests that some primary-exclusive methods fail when called by the secondaries"""
     secondary = neat.DistributedEvaluator(
         ("localhost", 8022),
-        authkey=b"abcd1234",
+        authkey=u"abcd1234",
         eval_function=eval_dummy_genome_nn,
         mode=MODE_SECONDARY,
         )
@@ -193,7 +216,7 @@ def test_distributed_evaluation_multiprocessing(do_mwcp=True):
     created using the multiprocessing module.
     """
     addr = ("localhost", random.randint(12000, 30000))
-    authkey = b"abcd1234"
+    authkey = u"abcd1234"
     mp = multiprocessing.Process(
         name="Primary evaluation process",
         target=run_primary,
@@ -262,7 +285,7 @@ def test_distributed_evaluation_threaded():
     if not HAVE_THREADING:
         raise unittest.SkipTest("Platform does not have threading")
     addr = ("localhost", random.randint(12000, 30000))
-    authkey = b"abcd1234"
+    authkey = u"abcd1234"
     mp = threading.Thread(
         name="Primary evaluation thread",
         target=run_primary,

--- a/tests/test_xor_example_distributed.py
+++ b/tests/test_xor_example_distributed.py
@@ -59,6 +59,7 @@ def run_primary(addr, authkey, generations):
     winner = p.run(de.evaluate, generations)
     print("===== stopping DistributedEvaluator =====")
     de.stop(wait=3, shutdown=True, force_secondary_shutdown=False)
+    print("===== DistributedEvaluator stopped. =====")
 
     if winner:
         # Display the winning genome.
@@ -83,8 +84,9 @@ def run_primary(addr, authkey, generations):
         time.sleep(3)
         de.start()
         winner2 = p2.run(de.evaluate, (100-checkpointer.last_generation_checkpoint))
-        print ("===== stopping DistributedEvaluator (forced) =====")
+        print("===== stopping DistributedEvaluator (forced) =====")
         de.stop(wait=3, shutdown=True, force_secondary_shutdown=True)
+        print("===== DistributedEvaluator stopped. =====")
 
         if winner2:
             if not winner:
@@ -128,14 +130,14 @@ def run_secondary(addr, authkey, num_workers=1):
         raise Exception("DistributedEvaluator in secondary mode did not try to exit!")
 
 
-@unittest.skipIf(ON_PYPY, "This test fails on pypy during travis builds (frequently due to timeouts) but usually works locally.")
+# @unittest.skipIf(ON_PYPY, "This test fails on pypy during travis builds (frequently due to timeouts) but usually works locally.")
 def test_xor_example_distributed():
     """
     Test to make sure restoration after checkpoint works with distributed.
     """
 
     addr = ("localhost", random.randint(12000, 30000))
-    authkey = b"abcd1234"
+    authkey = "abcd1234"
     mp = multiprocessing.Process(
         name="Primary evaluation process",
         target=run_primary,

--- a/tests/test_xor_example_distributed.py
+++ b/tests/test_xor_example_distributed.py
@@ -122,12 +122,19 @@ def run_secondary(addr, authkey, num_workers=1):
         mode=MODE_SECONDARY,
         num_workers=num_workers,
         )
-    try:
-        de.start(secondary_wait=3, exit_on_stop=True, reconnect=True)
-    except SystemExit:
-        pass
-    else:
-        raise Exception("DistributedEvaluator in secondary mode did not try to exit!")
+    max_tries = 3
+    for i in range(max_tries):
+        # sometimes it may take a while before the port used is available again
+        try:
+            de.start(secondary_wait=3, exit_on_stop=True, reconnect=True)
+        except SystemExit:
+            # expected
+            break
+        except OSError:
+            if i == (max_tries -1):
+                raise
+        else:
+            raise Exception("DistributedEvaluator in secondary mode did not try to exit!")
 
 
 # @unittest.skipIf(ON_PYPY, "This test fails on pypy during travis builds (frequently due to timeouts) but usually works locally.")


### PR DESCRIPTION
I finally found time to complete the rewrite of `distributed.py`.
This PR replaces the usage of the `multiprocessing.managers` module with the `socket` module.
Here are some advantages of this change:
- improved stability and performance (tests will no longer fail due to timeout errors)
- we can now use our own serialization functions instead of relying on pickle, which may be useful if we implement xml/json/... serialization)

These changes are **mostly** compatible with the old API, however the type of the `authkey` argument has changed from `bytes` to `str`/`unicode`.

Also, this closes #101.