### PR TITLE
New activation functions

### DIFF
--- a/neat/activations.py
+++ b/neat/activations.py
@@ -31,6 +31,11 @@ def gauss_activation(z):
 def relu_activation(z):
     return z if z > 0.0 else 0.0
 
+def elu_activation(z):
+    return z if z > 0.0 else math.exp(z) - 1
+
+def lelu_activation(z, leaky=0.005):
+    return z if z > 0.0 else 0.005*z
 
 def softplus_activation(z):
     z = max(-60.0, min(60.0, 5.0 * z))
@@ -107,6 +112,8 @@ class ActivationFunctionSet(object):
         self.add('sin', sin_activation)
         self.add('gauss', gauss_activation)
         self.add('relu', relu_activation)
+        self.add('elu', elu_activation)
+        self.add('lelu', lelu_activation)
         self.add('softplus', softplus_activation)
         self.add('identity', identity_activation)
         self.add('clamped', clamped_activation)

--- a/neat/activations.py
+++ b/neat/activations.py
@@ -37,6 +37,9 @@ def elu_activation(z):
 def lelu_activation(z, leaky=0.005):
     return z if z > 0.0 else 0.005*z
 
+def selu_activation(z, lam=1.0507009873554804934193349852946, alpha=1.6732632423543772848170429916717):
+    return lam*z if z > 0.0 else lam*alpha*(math.exp(z) - 1)
+
 def softplus_activation(z):
     z = max(-60.0, min(60.0, 5.0 * z))
     return 0.2 * math.log(1 + math.exp(z))
@@ -114,6 +117,7 @@ class ActivationFunctionSet(object):
         self.add('relu', relu_activation)
         self.add('elu', elu_activation)
         self.add('lelu', lelu_activation)
+        self.add('selu', selu_activation)
         self.add('softplus', softplus_activation)
         self.add('identity', identity_activation)
         self.add('clamped', clamped_activation)


### PR DESCRIPTION
```
Not to be presumptuous, but `master` is the only branch that I could think to point the PR.
```
I've added the activation functions that I use the most (SeLU, eLU, LeLU) -- when manually setting the hyperparameters. These come from various other papers. I nominally run a DNN with each of the activation functions, and the select the one that has the best validation accuracy in the least number of iterations.  This would likely be better optimized when using comparative activation functions with NEAT.

Edits:

Added three new to `neat/activation.py`: 

```python
def relu_activation(z):
    return z if z > 0.0 else 0.0

def elu_activation(z):
    return z if z > 0.0 else math.exp(z) - 1

def selu_activation(z, lam=1.0507009873554804934193349852946, alpha=1.6732632423543772848170429916717):
    return lam*z if z > 0.0 else lam*alpha*(math.exp(z) - 1)
```

The funky values for `lam` and `alpha` values come from the paper: 

https://arxiv.org/pdf/1706.02515.pdf

but I found them on Reddit at 

https://www.reddit.com/r/MachineLearning/comments/6g5tg1/r_selfnormalizing_neural_networks_improved_elu/