### PR TITLE
ranges do not return list items in python 3, convert to list

### DIFF
--- a/neat/nn/recurrent.py
+++ b/neat/nn/recurrent.py
@@ -10,7 +10,7 @@ class RecurrentNetwork(object):
 
         self.values = [{}, {}]
         for v in self.values:
-            for k in inputs + outputs:
+            for k in list(inputs) + list(outputs):
                 v[k] = 0.0
 
             for node, ignored_activation, ignored_aggregation, ignored_bias, ignored_response, links in self.node_evals:


### PR DESCRIPTION
just a python 3 compatibility fixed by converting ranges to lists (was previously the return val of a range)