### PR TITLE
Fixed ZeroDivisionError if pop_size is set to 1

### DIFF
--- a/neat/reproduction.py
+++ b/neat/reproduction.py
@@ -28,7 +28,7 @@ class DefaultReproduction(DefaultClassConfig):
         return DefaultClassConfig(param_dict,
                                   [ConfigParameter('elitism', int, 0),
                                    ConfigParameter('survival_threshold', float, 0.2),
-                                   ConfigParameter('min_species_size', int, 2)])
+                                   ConfigParameter('min_species_size', int, 1)])
 
     def __init__(self, config, reporters, stagnation):
         # pylint: disable=super-init-not-called

--- a/neat/species.py
+++ b/neat/species.py
@@ -134,10 +134,12 @@ class DefaultSpeciesSet(DefaultClassConfig):
             member_dict = dict((gid, population[gid]) for gid in members)
             s.update(population[rid], member_dict)
 
-        gdmean = mean(distances.distances.values())
-        gdstdev = stdev(distances.distances.values())
-        self.reporters.info(
-            'Mean genetic distance {0:.3f}, standard deviation {1:.3f}'.format(gdmean, gdstdev))
+        # Mean and std genetic distance info report
+        if len(population) > 1:
+            gdmean = mean(distances.distances.values())
+            gdstdev = stdev(distances.distances.values())
+            self.reporters.info(
+                'Mean genetic distance {0:.3f}, standard deviation {1:.3f}'.format(gdmean, gdstdev))
 
     def get_species_id(self, individual_id):
         return self.genome_to_species[individual_id]


### PR DESCRIPTION
There's currently a bug where if the population size is 1, neat will raise a ZeroDivisionError exception.

Adding the following check to _'species.py'_ fixes that:
`if len(population) > 1:`

In addition, changing the config parameter in '_reproduction.py_' from **2** to **1**.