### PR TITLE
Adding an argument to the config object

### DIFF
--- a/neat/config.py
+++ b/neat/config.py
@@ -133,7 +133,7 @@ class Config(object):
                 ConfigParameter('reset_on_extinction', bool),
                 ConfigParameter('no_fitness_termination', bool, False)]
 
-    def __init__(self, genome_type, reproduction_type, species_set_type, stagnation_type, filename):
+    def __init__(self, genome_type, reproduction_type, species_set_type, stagnation_type, filename, config_information):
         # Check that the provided types have the required methods.
         assert hasattr(genome_type, 'parse_config')
         assert hasattr(reproduction_type, 'parse_config')
@@ -144,6 +144,7 @@ class Config(object):
         self.reproduction_type = reproduction_type
         self.species_set_type = species_set_type
         self.stagnation_type = stagnation_type
+        self.config_information = config_information
 
         if not os.path.isfile(filename):
             raise Exception('No such config file: ' + os.path.abspath(filename))

--- a/neat/config.py
+++ b/neat/config.py
@@ -133,7 +133,7 @@ class Config(object):
                 ConfigParameter('reset_on_extinction', bool),
                 ConfigParameter('no_fitness_termination', bool, False)]
 
-    def __init__(self, genome_type, reproduction_type, species_set_type, stagnation_type, filename, config_information):
+    def __init__(self, genome_type, reproduction_type, species_set_type, stagnation_type, filename, config_information=None):
         # Check that the provided types have the required methods.
         assert hasattr(genome_type, 'parse_config')
         assert hasattr(reproduction_type, 'parse_config')


### PR DESCRIPTION
When you call the function run of the Pupolation object you're not allowed to pass more than two arguments to the fitness_function but one of the two arguments is the Config object where I added a simple variable to make possible the passing of at least one number, for example, the ID of a player using the AI 