### PR TITLE
Bug fix regarding checkpoint generation number

### DIFF
--- a/neat/checkpoint.py
+++ b/neat/checkpoint.py
@@ -32,7 +32,7 @@ class Checkpointer(BaseReporter):
         self.filename_prefix = filename_prefix
 
         self.current_generation = None
-        self.last_generation_checkpoint = -1
+        self.last_generation_checkpoint = 0
         self.last_time_checkpoint = time.time()
 
     def start_generation(self, generation):
@@ -47,13 +47,13 @@ class Checkpointer(BaseReporter):
                 checkpoint_due = True
 
         if (checkpoint_due is False) and (self.generation_interval is not None):
-            dg = self.current_generation - self.last_generation_checkpoint
+            dg = self.current_generation + 1 - self.last_generation_checkpoint
             if dg >= self.generation_interval:
                 checkpoint_due = True
 
         if checkpoint_due:
-            self.save_checkpoint(config, population, species_set, self.current_generation)
-            self.last_generation_checkpoint = self.current_generation
+            self.save_checkpoint(config, population, species_set, self.current_generation + 1)
+            self.last_generation_checkpoint = self.current_generation + 1
             self.last_time_checkpoint = time.time()
 
     def save_checkpoint(self, config, population, species_set, generation):
@@ -71,7 +71,6 @@ class Checkpointer(BaseReporter):
         with gzip.open(filename) as f:
             generation, config, population, species_set, rndstate = pickle.load(f)
             random.setstate(rndstate)
-            generation += 1 
             population = Population(config, (population, species_set, generation))
             # since the saved population is already trained
             return Population(config, (population, species_set, generation))

--- a/neat/checkpoint.py
+++ b/neat/checkpoint.py
@@ -71,7 +71,7 @@ class Checkpointer(BaseReporter):
         with gzip.open(filename) as f:
             generation, config, population, species_set, rndstate = pickle.load(f)
             random.setstate(rndstate)
-            generation += 1 # we are training the end of previos the generation actually meaning the next one
+            generation += 1 
             population = Population(config, (population, species_set, generation))
             # since the saved population is already trained
             return Population(config, (population, species_set, generation))

--- a/neat/checkpoint.py
+++ b/neat/checkpoint.py
@@ -71,4 +71,7 @@ class Checkpointer(BaseReporter):
         with gzip.open(filename) as f:
             generation, config, population, species_set, rndstate = pickle.load(f)
             random.setstate(rndstate)
+            generation += 1 # we are training the end of previos the generation actually meaning the next one
+            population = Population(config, (population, species_set, generation))
+            # since the saved population is already trained
             return Population(config, (population, species_set, generation))


### PR DESCRIPTION
Related to #132

When saving a checkpoint for a generation let's say n , we are not actually saving the last trained generation, we are saving the newly created generation based on generation n so therefore the generation n+1.

`
            self.population = self.reproduction.reproduce(self.config, self.species,
                                                          self.config.pop_size, self.generation)
`
is before
`
self.reporters.end_generation(self.config, self.population, self.species)
`

 In the current implementation, when loading a checkpoint, it loads it as the n-th generation and overwrites the checkpoint - n even thought it is actually the n+1 generation that's named n. This could cause some loss of generations if we load the checkpoint many times and also some confusion as stated in the issue above. I added the fix that was discussed there