### PR TITLE
Add `abs` to decrement of fitness in eval_genomes

### DIFF
--- a/examples/xor/evolve-feedforward.py
+++ b/examples/xor/evolve-feedforward.py
@@ -18,7 +18,7 @@ def eval_genomes(genomes, config):
         net = neat.nn.FeedForwardNetwork.create(genome, config)
         for xi, xo in zip(xor_inputs, xor_outputs):
             output = net.activate(xi)
-            genome.fitness -= (output[0] - xo[0]) ** 2
+            genome.fitness -= abs(output[0] - xo[0]) ** 2
 
 
 def run(config_file):


### PR DESCRIPTION
Let's say we test xor_inputs[1] in the current iteration. The expected output would be xor_outputs[1], meaning 1. `output = net.activate(xi)` will now let the model predict an output. In our example, the model predicts 0. Based on that the following line should remove fitness for the wrong guess. Though through the fact, xo[0] would be 1 and output would be 0, the line `genome.fitness -= (output[0] - xo[0]) ** 2` would not decrease the genome.fitness variable but rather increase it.