### PR TITLE
Set genome_indexer to last key in population +1 on checkpoint restore

### DIFF
--- a/neat/population.py
+++ b/neat/population.py
@@ -1,5 +1,7 @@
 """Implements the core evolution algorithm."""
 
+from itertools import count
+
 from neat.math_util import mean
 from neat.reporting import ReporterSet
 
@@ -45,6 +47,10 @@ class Population(object):
             self.species.speciate(config, self.population, self.generation)
         else:
             self.population, self.species, self.generation = initial_state
+            # If the reproduction object has a genome indexer, 
+            # set it to continue from the last genome ID.
+            if hasattr(self.reproduction, "genome_indexer"):
+                self.reproduction.genome_indexer = count(max(self.population.keys()) + 1)
 
         self.best_genome = None
 

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -35,6 +35,39 @@ class PopulationTests(unittest.TestCase):
         with self.assertRaises(Exception):
             p = neat.Population(config)
 
+    def test_count_after_checkpoint_restore(self):
+        """
+        Test that the genome indexer in DefaultGenome continues from the last genome ID
+        after restoring from a checkpoint.
+        """
+        # Load configuration.
+        local_dir = os.path.dirname(__file__)
+        config_path = os.path.join(local_dir, 'test_configuration')
+        config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
+                             neat.DefaultSpeciesSet, neat.DefaultStagnation,
+                             config_path)
+
+        p = neat.Population(config)
+        filename_prefix = 'neat-checkpoint-test_population'
+        checkpointer = neat.Checkpointer(1, 5, filename_prefix=filename_prefix)
+        p.add_reporter(checkpointer)
+
+        def eval_genomes(genomes, config):
+            for genome_id, genome in genomes:
+                genome.fitness = 0.5
+
+        p.run(eval_genomes, 5)
+
+        filename = '{0}{1}'.format(
+            filename_prefix, checkpointer.last_generation_checkpoint
+        )
+        restored_population = neat.Checkpointer.restore_checkpoint(filename)
+        last_genome_key = max([x.key for x in p.population.values()])
+        
+        self.assertEqual(
+            next(restored_population.reproduction.genome_indexer),
+            last_genome_key + 1
+        )
 
 # def test_minimal():
 #     # sample fitness function


### PR DESCRIPTION
When restoring a population from a checkpoint, the `genome_indexer` count is re-initialized from 1, and this causes genomes to be overwritten when the keys collide. 

I came across the issue when I was investigating why my best genomes in a species would suddenly drop in fitness even if I had elitism configured and was using a deterministic fitness function. Turns out they were being overwritten by new children that were given the same key. I also kept getting smaller populations than the size defined in the config, and I think this is the reason for that as well.

This PR adds functionality that re-initializes the `genome_indexer` count to the last key in the population + 1.

I'm not sure if I've implemented the fix in the correct place, so let me know if I should make changes to better align with the project conventions :)