### PR TITLE
Set new reporters on restored species object

### DIFF
--- a/neat/population.py
+++ b/neat/population.py
@@ -48,6 +48,7 @@ class Population(object):
             self.species.speciate(config, self.population, self.generation)
         else:
             self.population, self.species, self.generation = initial_state
+            self.species.reporters = self.reporters
             # If the reproduction object has a genome indexer, 
             # set it to continue from the last genome ID.
             if hasattr(self.reproduction, "genome_indexer"):


### PR DESCRIPTION
When restoring a population from a checkpoint, the ReporterSet is reinitialized on the reproduction object, but restored from the checkpoint on the species object. This can cause unexpected behavior.

This PR sets the newly initialized ReporterSet on the species object after it's been assigned by the initial state.