### PR TITLE
Validate aggregation callables with single-argument bind check

### DIFF
--- a/neat/aggregations.py
+++ b/neat/aggregations.py
@@ -3,6 +3,7 @@ Has the built-in aggregation functions, code for using them,
 and code for adding new user-defined ones.
 """
 
+import inspect
 import types
 import warnings
 from functools import reduce
@@ -49,14 +50,27 @@ class InvalidAggregationFunction(TypeError):
 
 
 def validate_aggregation(function):  # TODO: Recognize when need `reduce`
-    if not isinstance(function,
-                      (types.BuiltinFunctionType,
-                       types.FunctionType,
-                       types.LambdaType)):
-        raise InvalidAggregationFunction("A function object is required.")
+    if not callable(function):
+        raise InvalidAggregationFunction("A callable object is required.")
 
-    if not (function.__code__.co_argcount >= 1):
-        raise InvalidAggregationFunction("A function taking at least one argument is required")
+    try:
+        signature = inspect.signature(function)
+    except (TypeError, ValueError) as exc:
+        if isinstance(function, types.BuiltinFunctionType):
+            return
+        raise InvalidAggregationFunction("Unable to inspect aggregation callable signature.") from exc
+
+    accepts_positional = any(
+        parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.VAR_POSITIONAL,
+        )
+        for parameter in signature.parameters.values()
+    )
+
+    if not accepts_positional:
+        raise InvalidAggregationFunction("A function taking at least one positional argument is required")
 
 
 class AggregationFunctionSet:

--- a/neat/aggregations.py
+++ b/neat/aggregations.py
@@ -56,6 +56,8 @@ def validate_aggregation(function):
     try:
         signature = inspect.signature(function)
     except (TypeError, ValueError) as exc:
+        # CPython builtins (e.g. max, sum) often lack introspectable signatures.
+        # Skip signature validation for these; they are assumed correct.
         if isinstance(function, types.BuiltinFunctionType):
             return
         raise InvalidAggregationFunction("Unable to inspect aggregation callable signature.") from exc
@@ -64,7 +66,7 @@ def validate_aggregation(function):
         signature.bind(object())
     except TypeError as exc:
         raise InvalidAggregationFunction(
-            "A function taking a single positional argument is required"
+            "A callable with exactly one required positional argument is required"
         ) from exc
 
 

--- a/neat/aggregations.py
+++ b/neat/aggregations.py
@@ -49,7 +49,7 @@ class InvalidAggregationFunction(TypeError):
     pass
 
 
-def validate_aggregation(function):  # TODO: Recognize when need `reduce`
+def validate_aggregation(function):
     if not callable(function):
         raise InvalidAggregationFunction("A callable object is required.")
 
@@ -60,17 +60,12 @@ def validate_aggregation(function):  # TODO: Recognize when need `reduce`
             return
         raise InvalidAggregationFunction("Unable to inspect aggregation callable signature.") from exc
 
-    accepts_positional = any(
-        parameter.kind in (
-            inspect.Parameter.POSITIONAL_ONLY,
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.VAR_POSITIONAL,
-        )
-        for parameter in signature.parameters.values()
-    )
-
-    if not accepts_positional:
-        raise InvalidAggregationFunction("A function taking at least one positional argument is required")
+    try:
+        signature.bind(object())
+    except TypeError as exc:
+        raise InvalidAggregationFunction(
+            "A function taking a single positional argument is required"
+        ) from exc
 
 
 class AggregationFunctionSet:

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -91,6 +91,10 @@ def keyword_only_function(*, items):
     return sum(items)
 
 
+def two_argument_function(items, scale):
+    return sum(items) * scale
+
+
 def test_function_set():
     s = aggregations.AggregationFunctionSet()
     assert s.get('sum') is not None
@@ -163,6 +167,21 @@ def test_bad_add3():
         pass
     else:
         raise Exception("Should have had a TypeError/derived for keyword_only_function")
+
+
+def test_bad_add4():
+    local_dir = os.path.dirname(__file__)
+    config_path = os.path.join(local_dir, 'test_configuration')
+    config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
+                         neat.DefaultSpeciesSet, neat.DefaultStagnation,
+                         config_path)
+
+    try:
+        config.genome_config.add_aggregation('two_argument_function', two_argument_function)
+    except TypeError:
+        pass
+    else:
+        raise Exception("Should have had a TypeError/derived for two_argument_function")
 
 
 if __name__ == '__main__':

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -72,8 +72,23 @@ def test_add_minabs():
     assert config.genome_config.aggregation_function_defs.is_valid('minabs')
 
 
+def test_add_builtin_max():
+    local_dir = os.path.dirname(__file__)
+    config_path = os.path.join(local_dir, 'test_configuration')
+    config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
+                         neat.DefaultSpeciesSet, neat.DefaultStagnation,
+                         config_path)
+
+    config.genome_config.add_aggregation('builtin_max', max)
+    assert config.genome_config.aggregation_function_defs.get('builtin_max') is max
+
+
 def dud_function():
     return 0.0
+
+
+def keyword_only_function(*, items):
+    return sum(items)
 
 
 def test_function_set():
@@ -133,6 +148,21 @@ def test_bad_add2():
         pass
     else:
         raise Exception("Should have had a TypeError/derived for dud_function")
+
+
+def test_bad_add3():
+    local_dir = os.path.dirname(__file__)
+    config_path = os.path.join(local_dir, 'test_configuration')
+    config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
+                         neat.DefaultSpeciesSet, neat.DefaultStagnation,
+                         config_path)
+
+    try:
+        config.genome_config.add_aggregation('keyword_only_function', keyword_only_function)
+    except TypeError:
+        pass
+    else:
+        raise Exception("Should have had a TypeError/derived for keyword_only_function")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What changed
- tightened `validate_aggregation` so custom aggregation callables must be invokable with a single positional argument (the iterable of node inputs)
- replaced the previous positional-parameter presence check with `inspect.Signature.bind` validation using one positional argument
- added a regression test (`test_bad_add4`) to reject two-required-argument aggregation functions at registration time

## Why
- aggregation functions are always called with one argument in runtime paths (`aggregation(node_inputs)`)
- before this change, functions that required two positional arguments could be registered and only fail later during network execution
- failing fast at config/registration time provides clearer feedback and prevents hard-to-debug runtime errors

## Testing
- ✅ `source .venv/bin/activate && pytest -q tests/test_aggregation.py`
- ✅ `source .venv/bin/activate && pytest -q`
